### PR TITLE
added configuration to install demo feature by default

### DIFF
--- a/distributions/distribution-resources/src/main/resources/conf/services/addons.cfg
+++ b/distributions/distribution-resources/src/main/resources/conf/services/addons.cfg
@@ -1,0 +1,27 @@
+# The base installation package of this openHAB instance
+# Valid options:
+#   - minimal  : Installation only with dashboard, but no UIs or other addons
+#   - standard : Typical installation with all standards UIs
+#   - demo     : A demo setup which includes UIs, a few bindings, config files etc.
+package = demo
+
+# A comma-separated list of bindings to install (e.g. "sonos,knx,zwave")
+binding = 
+
+# A comma-separated list of UIs to install (e.g. "basic,paper")
+ui = 
+
+# A comma-separated list of persistence services to install (e.g. "rrd4j,jpa")
+persistence = 
+
+# A comma-separated list of actions to install (e.g. "mail,pushover")
+action = 
+
+# A comma-separated list of transformation services to install (e.g. "map,jsonpath")
+transformation = 
+
+# A comma-separated list of text-to-speech engines to install (e.g. "marytts,freetts")
+tts = 
+
+# A comma-separated list of miscellaneous services to install (e.g. "myopenhab")
+misc = 

--- a/features/openhab-demo/src/main/feature/feature.xml
+++ b/features/openhab-demo/src/main/feature/feature.xml
@@ -3,9 +3,11 @@
 
     <!-- <feature name="${project.artifactId}" description="${project.name}" version="${project.version}"> -->
 
-    <feature name="openhab-demo" description="${project.name}" version="${project.version}">
-        <details>${project.description}</details>
+    <feature name="openhab-package-demo" description="openHAB Demo Package" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>openhab-misc-restdocs</feature>
         <feature>openhab-ui-basic</feature>
+        <feature>openhab-ui-classic</feature>
         <feature>openhab-ui-paper</feature>
         <feature>openhab-binding-yahooweather</feature>
         <feature>openhab-binding-wemo</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,17 @@
         <system>Github</system>
     </issueManagement>
 
+    <distributionManagement>
+        <repository>
+            <id>bintray</id>
+            <url>https://api.bintray.com/maven/openhab/mvn/openhab-distro/;publish=1</url>
+        </repository>
+        <snapshotRepository>
+            <id>jfrog</id>
+            <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <properties>
         <esh.version>0.8.0-SNAPSHOT</esh.version>
         <ohc.version>2.0.0-SNAPSHOT</ohc.version>


### PR DESCRIPTION
This now makes use of https://github.com/kaikreuzer/openhab-core/commit/4e88685bd878acece4bbe37636011bf811d30576

Signed-off-by: Kai Kreuzer <kai@openhab.org>