### PR TITLE
added an initial welcome echo when starting the runtime

### DIFF
--- a/distributions/distribution-resources/src/main/resources/home/start.bat
+++ b/distributions/distribution-resources/src/main/resources/home/start.bat
@@ -1,5 +1,7 @@
 @echo off
 
+echo Launching the openHAB runtime...
+
 setlocal
 set DIRNAME=%~dp0%
 "%DIRNAME%runtime\karaf\bin\karaf.bat" %*

--- a/distributions/distribution-resources/src/main/resources/home/start.sh
+++ b/distributions/distribution-resources/src/main/resources/home/start.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
+echo Launching the openHAB runtime...
+
 DIRNAME=`dirname "$0"`
 exec "${DIRNAME}/runtime/karaf/bin/karaf" "${@}"

--- a/distributions/distribution-resources/src/main/resources/home/start_debug.bat
+++ b/distributions/distribution-resources/src/main/resources/home/start_debug.bat
@@ -1,5 +1,7 @@
 @echo off
 
+echo Launching the openHAB runtime...
+
 setlocal
 set DIRNAME=%~dp0%
 "%DIRNAME%start.bat" debug %*

--- a/distributions/distribution-resources/src/main/resources/home/start_debug.sh
+++ b/distributions/distribution-resources/src/main/resources/home/start_debug.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
+echo Launching the openHAB runtime...
+
 DIRNAME=`dirname "$0"`
 exec "${DIRNAME}/start.sh" debug "${@}"


### PR DESCRIPTION
As startup can take a while, a first message for the user is always welcome - this is taken from the current openHAB 2 runtime.

Signed-off-by: Kai Kreuzer <kai@openhab.org>