### PR TITLE
Remove swagger fixed host name, so that it can be generated dynamically.

### DIFF
--- a/distributions/distribution-resources/src/main/resources/runtime/etc/services.cfg
+++ b/distributions/distribution-resources/src/main/resources/runtime/etc/services.cfg
@@ -25,7 +25,6 @@ org.jupnp:threadPoolSize=200
 
 com.eclipsesource.jaxrs.connector:root=/rest
 com.eclipsesource.jaxrs.swagger.config:swagger.basePath=/rest
-com.eclipsesource.jaxrs.swagger.config:swagger.host=localhost:8080
 com.eclipsesource.jaxrs.swagger.config:swagger.info.title=openHAB REST API
 
 # Configuration of scheduled thread pool sizes


### PR DESCRIPTION
Resolves https://github.com/kaikreuzer/openhab-core/issues/7

Signed-off-by: Davy Vanherbergen <davy.vanherbergen@gmail.com>