### PR TITLE
Enable logging to events.log

### DIFF
--- a/distributions/distribution-resources/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distributions/distribution-resources/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -3,7 +3,7 @@ log4j.rootLogger = WARN, out, osgi:*
 log4j.throwableRenderer=org.apache.log4j.OsgiThrowableRenderer
 
 # openHAB specific logger configuration
-log4j.logger.smarthome.event = INFO
+log4j.logger.smarthome.event = INFO, event
 log4j.logger.smarthome.event.ItemStateEvent = ERROR
 log4j.logger.smarthome.event.ThingStatusInfoEvent = ERROR
 
@@ -28,7 +28,7 @@ log4j.appender.out.maxBackupIndex=10
 # File appender - events.log
 log4j.appender.event=org.apache.log4j.RollingFileAppender
 log4j.appender.event.layout=org.apache.log4j.PatternLayout
-log4j.appender.event.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%-20.20c{1}] - %m%n
+log4j.appender.event.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%-26.26c{1}] - %m%n
 log4j.appender.event.file=${karaf.data}/logs/events.log
 log4j.appender.event.append=true
 log4j.appender.event.maxFileSize=10MB


### PR DESCRIPTION
Resolves #58. Class name is no longer abbreviated, so that it becomes easy to scan the log for similar event types.

Signed-off-by: Davy Vanherbergen <davy.vanherbergen@gmail.com>