### PR TITLE
[build fix] karaf 4.0.4-snapshot no longer available. 

### DIFF
--- a/features/openhab-aggregate-kar/pom.xml
+++ b/features/openhab-aggregate-kar/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
-                <version>4.0.4-SNAPSHOT</version>
+                <version>${dep.karaf.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <startLevel>80</startLevel>


### PR DESCRIPTION
Signed-off-by: Davy Vanherbergen <davy.vanherbergen@gmail.com>