### PR TITLE
enabled Equinox compatibility mode for boot delegation

### DIFF
--- a/distributions/distribution-resources/src/main/resources/etc/custom.properties
+++ b/distributions/distribution-resources/src/main/resources/etc/custom.properties
@@ -1,2 +1,3 @@
 karaf.systemBundlesStartLevel=50
 karaf.framework=equinox
+osgi.compatibility.bootdelegation=true


### PR DESCRIPTION
see https://wiki.eclipse.org/Equinox_Boot_Delegation
resolves #85

Signed-off-by: Kai Kreuzer <kai@openhab.org>