### PR TITLE
changes for Xtext 2.9.2 usage (ESH / OH)

### DIFF
--- a/distributions/openhab-offline/pom.xml
+++ b/distributions/openhab-offline/pom.xml
@@ -18,13 +18,13 @@
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>framework</artifactId>
-            <version>${karaf.features.version}</version>
+            <version>${karaf.version}</version>
             <type>kar</type>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>standard</artifactId>
-            <version>${karaf.features.version}</version>
+            <version>${karaf.version}</version>
             <classifier>features</classifier>
             <type>xml</type>
         </dependency>

--- a/distributions/openhab-offline/pom.xml
+++ b/distributions/openhab-offline/pom.xml
@@ -45,11 +45,11 @@
         </dependency>
         <!-- Temporary patch for https://github.com/openhab/openhab-distro/issues/10 -->
         <dependency>
-          	<groupId>org.openhab.distro.deps</groupId>
-  			<artifactId>pax-web-jetty</artifactId>
-  			<version>4.2.3.sp1</version>
-			<scope>provided</scope>
-  		</dependency>
+            <groupId>org.openhab.distro.deps</groupId>
+            <artifactId>pax-web-jetty</artifactId>
+            <version>4.2.4</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/distributions/openhab-offline/src/main/descriptors/archive.xml
+++ b/distributions/openhab-offline/src/main/descriptors/archive.xml
@@ -97,9 +97,9 @@
         </file>      
         <!-- add patch for https://github.com/openhab/openhab-distro/issues/10 -->
         <file>
-            <source>target/assembly/system/org/openhab/distro/deps/pax-web-jetty/4.2.3.sp1/pax-web-jetty-4.2.3.sp1.jar</source>
-            <outputDirectory>runtime/karaf/system/org/ops4j/pax/web/pax-web-jetty/4.2.3/</outputDirectory>
-            <destName>pax-web-jetty-4.2.3.jar</destName>
+            <source>target/assembly/system/org/openhab/distro/deps/pax-web-jetty/4.2.4/pax-web-jetty-4.2.4.jar</source>
+            <outputDirectory>runtime/karaf/system/org/ops4j/pax/web/pax-web-jetty/4.2.4/</outputDirectory>
+            <destName>pax-web-jetty-4.2.4.jar</destName>
         </file>
     </files>
 

--- a/distributions/openhab-offline/src/main/descriptors/archive.xml
+++ b/distributions/openhab-offline/src/main/descriptors/archive.xml
@@ -49,7 +49,7 @@
                 <include>system/**</include>
             </includes>
             <excludes>
-            	<exclude>system/**/pax-web-jetty*.jar</exclude>
+                <exclude>system/**/pax-web-jetty*.jar</exclude>
             </excludes>
         </fileSet>
 

--- a/distributions/openhab-online/pom.xml
+++ b/distributions/openhab-online/pom.xml
@@ -79,16 +79,16 @@
         </dependency>
         <!-- Temporary patch for https://github.com/openhab/openhab-distro/issues/10 -->
         <dependency>
-          	<groupId>org.openhab.distro.deps</groupId>
-  			<artifactId>pax-web-jetty</artifactId>
-  			<version>4.2.3.sp1</version>
-			<scope>provided</scope>
-  		</dependency>         
+            <groupId>org.openhab.distro.deps</groupId>
+            <artifactId>pax-web-jetty</artifactId>
+            <version>4.2.4</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <resources>
-        	<!-- add shared distribution resources -->
+            <!-- add shared distribution resources -->
             <resource>
                 <directory>../distribution-resources/src/main/resources</directory>
                 <filtering>false</filtering>
@@ -103,7 +103,7 @@
                     <include>**/*</include>
                 </includes>
             </resource>
-        	<!-- add distribution specific resources -->
+            <!-- add distribution specific resources -->
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>false</filtering>
@@ -117,7 +117,7 @@
                 <includes>
                     <include>**/*</include>
                 </includes>
-            </resource>            
+            </resource>
         </resources>
         <plugins>
             <plugin>

--- a/distributions/openhab-online/pom.xml
+++ b/distributions/openhab-online/pom.xml
@@ -38,14 +38,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>de.maggu2810.shk</groupId>
-            <artifactId>shk-feature-base</artifactId>
-            <version>${shk.version}</version>
-            <classifier>features</classifier>
-            <type>xml</type>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.openhab.core</groupId>
             <artifactId>openhab-core</artifactId>
             <version>${ohc.version}</version>

--- a/distributions/openhab-online/pom.xml
+++ b/distributions/openhab-online/pom.xml
@@ -18,13 +18,13 @@
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>framework</artifactId>
-            <version>${karaf.features.version}</version>
+            <version>${karaf.version}</version>
             <type>kar</type>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>standard</artifactId>
-            <version>${karaf.features.version}</version>
+            <version>${karaf.version}</version>
             <classifier>features</classifier>
             <type>xml</type>
             <scope>compile</scope>

--- a/distributions/openhab-online/src/main/descriptors/archive.xml
+++ b/distributions/openhab-online/src/main/descriptors/archive.xml
@@ -49,7 +49,7 @@
                 <include>system/**</include>
             </includes>
             <excludes>
-            	<exclude>pax-web-jetty*.jar</exclude>
+                <exclude>pax-web-jetty*.jar</exclude>
             </excludes>
         </fileSet>
 

--- a/distributions/openhab-online/src/main/descriptors/archive.xml
+++ b/distributions/openhab-online/src/main/descriptors/archive.xml
@@ -97,10 +97,10 @@
         </file>
         <!-- add patch for https://github.com/openhab/openhab-distro/issues/10 -->
         <file>
-            <source>target/assembly/system/org/openhab/distro/deps/pax-web-jetty/4.2.3.sp1/pax-web-jetty-4.2.3.sp1.jar</source>
-            <outputDirectory>runtime/karaf/system/org/ops4j/pax/web/pax-web-jetty/4.2.3/</outputDirectory>
-            <destName>pax-web-jetty-4.2.3.jar</destName>
-        </file>     
+            <source>target/assembly/system/org/openhab/distro/deps/pax-web-jetty/4.2.4/pax-web-jetty-4.2.4.jar</source>
+            <outputDirectory>runtime/karaf/system/org/ops4j/pax/web/pax-web-jetty/4.2.4/</outputDirectory>
+            <destName>pax-web-jetty-4.2.4.jar</destName>
+        </file>
     </files>
 
 </assembly>

--- a/features/openhab-aggregate-xml/pom.xml
+++ b/features/openhab-aggregate-xml/pom.xml
@@ -24,13 +24,6 @@
             <type>xml</type>
         </dependency>
         <dependency>
-            <groupId>de.maggu2810.shk</groupId>
-            <artifactId>shk-feature-base</artifactId>
-            <version>${shk.version}</version>
-            <classifier>features</classifier>
-            <type>xml</type>
-        </dependency>
-        <dependency>
             <groupId>org.openhab.core</groupId>
             <artifactId>openhab-core</artifactId>
             <version>${ohc.version}</version>
@@ -71,6 +64,55 @@
             <version>${project.version}</version>
             <type>pom</type>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.maggu2810.kat.features</groupId>
+            <artifactId>apache-commons</artifactId>
+            <version>${kat.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
+        <dependency>
+            <groupId>de.maggu2810.kat.features</groupId>
+            <artifactId>apache-httpcomponents</artifactId>
+            <version>${kat.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
+        <dependency>
+            <groupId>de.maggu2810.kat.features</groupId>
+            <artifactId>gson</artifactId>
+            <version>${kat.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
+        <dependency>
+            <groupId>de.maggu2810.kat.features</groupId>
+            <artifactId>jmdns</artifactId>
+            <version>${kat.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
+        <dependency>
+            <groupId>de.maggu2810.kat.features</groupId>
+            <artifactId>jupnp</artifactId>
+            <version>${kat.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
+        <dependency>
+            <groupId>de.maggu2810.kat.features</groupId>
+            <artifactId>paho</artifactId>
+            <version>${kat.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
+        <dependency>
+            <groupId>de.maggu2810.kat.features</groupId>
+            <artifactId>xtext</artifactId>
+            <version>${kat.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
         </dependency>
     </dependencies>
 

--- a/features/openhab-verify/pom.xml
+++ b/features/openhab-verify/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>framework</artifactId>
-            <version>${dep.karaf.version}</version>
+            <version>${karaf.version}</version>
             <type>kar</type>
             <scope>provided</scope>
         </dependency>
@@ -46,8 +46,8 @@
                         </goals>
                         <configuration>
                             <descriptors>
-                                <descriptor>mvn:org.apache.karaf.features/framework/${dep.karaf.version}/xml/features</descriptor>
-                                <descriptor>mvn:org.apache.karaf.features/standard/${dep.karaf.version}/xml/features</descriptor>
+                                <descriptor>mvn:org.apache.karaf.features/framework/${karaf.version}/xml/features</descriptor>
+                                <descriptor>mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features</descriptor>
                                 <descriptor>mvn:${project.groupId}/openhab-aggregate-xml/${project.version}/xml/features</descriptor>
                             </descriptors>
                             <distribution>org.apache.karaf.features:framework</distribution>

--- a/pom.xml
+++ b/pom.xml
@@ -45,10 +45,10 @@
 
     <properties>
         <esh.version>0.8.0-SNAPSHOT</esh.version>
-        <shk.version>1.2</shk.version>
         <ohc.version>2.0.0-SNAPSHOT</ohc.version>
         <oh2.version>2.0.0-SNAPSHOT</oh2.version>
         <oh1.version>1.9.0-SNAPSHOT</oh1.version>
+        <kat.version>1.4.1</kat.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.compilerVersion>1.8</maven.compiler.compilerVersion>
 
-        <karaf.version>4.0.3</karaf.version>
+        <karaf.version>4.0.4</karaf.version>
         <maven.compiler.plugin.version>3.3</maven.compiler.plugin.version>
         <build.helper.maven.plugin.version>1.9.1</build.helper.maven.plugin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.compilerVersion>1.8</maven.compiler.compilerVersion>
 
-        <dep.karaf.version>4.0.3</dep.karaf.version>
-        <karaf.maven.plugin.version>4.0.3</karaf.maven.plugin.version>
-        <karaf.features.version>4.0.3</karaf.features.version>
+        <karaf.version>4.0.3</karaf.version>
         <maven.compiler.plugin.version>3.3</maven.compiler.plugin.version>
         <build.helper.maven.plugin.version>1.9.1</build.helper.maven.plugin.version>
 
@@ -84,7 +82,7 @@
                 <plugin>
                     <groupId>org.apache.karaf.tooling</groupId>
                     <artifactId>karaf-maven-plugin</artifactId>
-                    <version>${karaf.maven.plugin.version}</version>
+                    <version>${karaf.version}</version>
                     <extensions>true</extensions>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Related to: https://github.com/eclipse/smarthome/pull/1383