### PR TITLE
removed tmp-shk maven repo for online distro (as all required content…

### DIFF
--- a/distributions/openhab-online/src/main/resources/etc/org.ops4j.pax.url.mvn.cfg
+++ b/distributions/openhab-online/src/main/resources/etc/org.ops4j.pax.url.mvn.cfg
@@ -80,7 +80,4 @@ org.ops4j.pax.url.mvn.repositories= \
  https://jcenter.bintray.com@id=oh-releases-repo, \
  https://repo.eclipse.org/content/repositories/releases@id=esh-release-repo, \
  http://oss.jfrog.org/libs-snapshot@id=oh-snapshot-repo@snapshots@noreleases, \
- https://repo.eclipse.org/content/repositories/snapshots@id=esh-snapshot-repo@snapshots@noreleases, \
- https://dl.bintray.com/maggu2810/maven@id=tmp-shk@snapshots
- 
-
+ https://repo.eclipse.org/content/repositories/snapshots@id=esh-snapshot-repo@snapshots@noreleases


### PR DESCRIPTION
… should be part of the pre-installed features)

@maggu2810 Can you confirm that my assumption is right that this repo is not relevant for any add-ons and is only required to construct the core distributions?

Signed-off-by: Kai Kreuzer <kai@openhab.org>