### PR TITLE
MapDB, Prowl, and Twitter seem to be working in OpenHAB 2

### DIFF
--- a/docs/sources/addons.md
+++ b/docs/sources/addons.md
@@ -78,6 +78,7 @@ All optional add-ons for openHAB 2 are part of the distribution. This includes a
 | Onkyo | Binding |
 | OpenEnergyMonitor | Binding |
 | OneWire | Binding |
+| Prowl | Action |
 | RFXCOM | Binding |
 | RWE SmartHome | Binding |
 | Samsung AC | Binding |
@@ -98,11 +99,13 @@ All optional add-ons for openHAB 2 are part of the distribution. This includes a
 | rrd4j | Persistence |
 | MySQL | Persistence |
 | MongoDB | Persistence |
+| MapDB | Persistence |
 | JPA | Persistence |
 | Mail | Action |
 | MiOS | Action |
 | Pushover | Action |
 | Telegram | Action |
+| Twitter  | Action |
 | XBMC | Action |
 | XMPP | Action |
 | GoogleTTS | TTS engine |


### PR DESCRIPTION
Currently MapDB can be used via addons.cfg; Prowl and Twitter must be installed manually.

With the action addons, I tested… 
Prowl: pushNotification(String subject, String message), pushNotification(String apiKey, String subject, String message), pushNotification(String apiKey, String subject, String message, int priority)
Twitter: sendTweet(String tweetTxt)