### PR TITLE
Add icons-classic folder and readme

### DIFF
--- a/distributions/distribution-resources/src/main/resources/conf/html/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/html/readme.txt
@@ -1,0 +1,2 @@
+Check out the openHAB2 documentation for more details:
+http://docs.openhab.org

--- a/distributions/distribution-resources/src/main/resources/conf/html/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/html/readme.txt
@@ -1,2 +1,3 @@
-Check out the openHAB2 documentation for more details:
-http://docs.openhab.org
+Serve your own static html pages or resources from here.
+Files stored in this folder will be available through the HTTP server of openHAB under 'http://<device-ip>:8080/static'.
+Resources for sitemap elements (image, video,...) can also be provided though this folder.

--- a/distributions/distribution-resources/src/main/resources/conf/icons/classic/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/icons/classic/readme.txt
@@ -2,5 +2,5 @@ Your additional icons go here.
 Icons can be provided as png (32x32) or preferably as svg files.
 ClassicUI and BasicUI can be configured to accept svg (default) or png icons.
 
-Check out the openHAB2 documentation for more details:
+Check out the openHAB documentation for more details:
 http://docs.openhab.org/configuration/icons.html

--- a/distributions/distribution-resources/src/main/resources/conf/icons/classic/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/icons/classic/readme.txt
@@ -1,8 +1,6 @@
-
-openHAB2 conf/icons/classic folder
-
-Your additional sitemap icons go here.
+Your additional icons go here.
 Icons can be provided as png (32x32) or preferably as svg files.
 ClassicUI and BasicUI can be configured to accept svg (default) or png icons.
 
-Check out the openHAB2 documentation for more details: http://docs.openhab.org
+Check out the openHAB2 documentation for more details:
+http://docs.openhab.org/configuration/icons.html

--- a/distributions/distribution-resources/src/main/resources/conf/icons/classic/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/icons/classic/readme.txt
@@ -1,0 +1,8 @@
+
+openHAB2 conf/icons/classic folder
+
+Your additional sitemap icons go here.
+Icons can be provided as png (32x32) or preferably as svg files.
+ClassicUI and BasicUI can be configured to accept svg (default) or png icons.
+
+Check out the openHAB2 documentation for more details: http://docs.openhab.org

--- a/distributions/distribution-resources/src/main/resources/conf/items/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/items/readme.txt
@@ -1,0 +1,7 @@
+
+openHAB2 conf/items folder
+
+Your item definitions go here.
+All items files have to have the ".items" file extension and must follow a special syntax.
+
+Check out the openHAB Wiki for more details: https://github.com/openhab/openhab/wiki/Explanation-of-items

--- a/distributions/distribution-resources/src/main/resources/conf/items/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/items/readme.txt
@@ -1,5 +1,5 @@
 Your item definitions go here.
 All items files have to have the ".items" file extension and must follow a special syntax.
 
-Check out the openHAB2 documentation for more details:
+Check out the openHAB documentation for more details:
 http://docs.openhab.org/configuration/items.html

--- a/distributions/distribution-resources/src/main/resources/conf/items/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/items/readme.txt
@@ -1,7 +1,5 @@
-
-openHAB2 conf/items folder
-
 Your item definitions go here.
 All items files have to have the ".items" file extension and must follow a special syntax.
 
-Check out the openHAB Wiki for more details: https://github.com/openhab/openhab/wiki/Explanation-of-items
+Check out the openHAB2 documentation for more details:
+http://docs.openhab.org/configuration/items.html

--- a/distributions/distribution-resources/src/main/resources/conf/persistence/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/persistence/readme.txt
@@ -1,7 +1,5 @@
-
-openHAB2 conf/persistence folder
-
 Your persistence configuration goes here.
 All persistence files have to have the ".persist" file extension and must follow a special syntax.
 
-Check out the openHAB2 documentation for more details: http://docs.openhab.org
+Check out the openHAB2 documentation for more details:
+http://docs.openhab.org/features/persistence.html

--- a/distributions/distribution-resources/src/main/resources/conf/persistence/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/persistence/readme.txt
@@ -1,0 +1,7 @@
+
+openHAB2 conf/persistence folder
+
+Your persistence configuration goes here.
+All persistence files have to have the ".persist" file extension and must follow a special syntax.
+
+Check out the openHAB2 documentation for more details: http://docs.openhab.org

--- a/distributions/distribution-resources/src/main/resources/conf/persistence/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/persistence/readme.txt
@@ -1,5 +1,5 @@
 Your persistence configuration goes here.
 All persistence files have to have the ".persist" file extension and must follow a special syntax.
 
-Check out the openHAB2 documentation for more details:
+Check out the openHAB documentation for more details:
 http://docs.openhab.org/features/persistence.html

--- a/distributions/distribution-resources/src/main/resources/conf/rules/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/rules/readme.txt
@@ -1,0 +1,7 @@
+
+openHAB2 conf/rules folder
+
+Your rules go here.
+All rule files have to have the ".rules" file extension and must follow a special syntax.
+
+Check out the openHAB Wiki for more details: https://github.com/openhab/openhab/wiki/Rules

--- a/distributions/distribution-resources/src/main/resources/conf/rules/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/rules/readme.txt
@@ -1,7 +1,5 @@
-
-openHAB2 conf/rules folder
-
 Your rules go here.
 All rule files have to have the ".rules" file extension and must follow a special syntax.
 
-Check out the openHAB Wiki for more details: https://github.com/openhab/openhab/wiki/Rules
+Check out the openHAB2 documentation for more details:
+http://docs.openhab.org/features/automation/ruledsl.html

--- a/distributions/distribution-resources/src/main/resources/conf/rules/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/rules/readme.txt
@@ -1,5 +1,5 @@
 Your rules go here.
 All rule files have to have the ".rules" file extension and must follow a special syntax.
 
-Check out the openHAB2 documentation for more details:
+Check out the openHAB documentation for more details:
 http://docs.openhab.org/features/automation/ruledsl.html

--- a/distributions/distribution-resources/src/main/resources/conf/scripts/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/scripts/readme.txt
@@ -1,0 +1,7 @@
+
+openHAB2 conf/scripts folder
+
+Your scripts go here.
+All script files have to have the ".script" file extension and must follow a special syntax.
+
+Check out the openHAB Wiki for more details: https://github.com/openhab/openhab/wiki/Scripts

--- a/distributions/distribution-resources/src/main/resources/conf/scripts/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/scripts/readme.txt
@@ -1,5 +1,5 @@
 Your scripts go here.
 All script files have to have the ".script" file extension and must follow a special syntax.
 
-Check out the openHAB2 documentation for more details:
+Check out the openHAB documentation for more details:
 http://docs.openhab.org/features/automation/ruledsl.html#scripts

--- a/distributions/distribution-resources/src/main/resources/conf/scripts/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/scripts/readme.txt
@@ -1,7 +1,5 @@
-
-openHAB2 conf/scripts folder
-
 Your scripts go here.
 All script files have to have the ".script" file extension and must follow a special syntax.
 
-Check out the openHAB Wiki for more details: https://github.com/openhab/openhab/wiki/Scripts
+Check out the openHAB2 documentation for more details:
+http://docs.openhab.org/features/automation/ruledsl.html#scripts

--- a/distributions/distribution-resources/src/main/resources/conf/services/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/services/readme.txt
@@ -3,4 +3,4 @@ All configuration files have to have the ".cfg" file extension.
 Service configuration files are automatically created as soon as you install an add-on that can be configured.
 
 Check out the openHAB2 documentation for more details:
-http://docs.openhab.org/configuration
+http://docs.openhab.org/configuration/services.html

--- a/distributions/distribution-resources/src/main/resources/conf/services/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/services/readme.txt
@@ -1,8 +1,6 @@
-
-openHAB2 conf/services folder
-
 Your service configurations will reside here.
 All configuration files have to have the ".cfg" file extension.
-Service configuration files will be automatically created as soon as you install a binding/ui/persistence/... that needs further configuration.
+Service configuration files are automatically created as soon as you install an add-on that can be configured.
 
-Check out the openHAB2 documentation for more details: http://docs.openhab.org
+Check out the openHAB2 documentation for more details:
+http://docs.openhab.org/configuration

--- a/distributions/distribution-resources/src/main/resources/conf/services/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/services/readme.txt
@@ -2,5 +2,5 @@ Your service configurations will reside here.
 All configuration files have to have the ".cfg" file extension.
 Service configuration files are automatically created as soon as you install an add-on that can be configured.
 
-Check out the openHAB2 documentation for more details:
+Check out the openHAB documentation for more details:
 http://docs.openhab.org/configuration/services.html

--- a/distributions/distribution-resources/src/main/resources/conf/services/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/services/readme.txt
@@ -1,0 +1,8 @@
+
+openHAB2 conf/services folder
+
+Your service configurations will reside here.
+All configuration files have to have the ".cfg" file extension.
+Service configuration files will be automatically created as soon as you install a binding/ui/persistence/... that needs further configuration.
+
+Check out the openHAB2 documentation for more details: http://docs.openhab.org

--- a/distributions/distribution-resources/src/main/resources/conf/sitemaps/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/sitemaps/readme.txt
@@ -1,7 +1,5 @@
-
-openHAB2 conf/sitemaps folder
-
 Your sitemap definitions go here.
 All sitemap files have to have the ".sitemap" file extension and must follow a special syntax.
 
-Check out the openHAB Wiki for more details: https://github.com/openhab/openhab/wiki/Explanation-of-Sitemaps
+Check out the openHAB2 documentation for more details:
+http://docs.openhab.org/features/sitemap.html

--- a/distributions/distribution-resources/src/main/resources/conf/sitemaps/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/sitemaps/readme.txt
@@ -1,5 +1,5 @@
 Your sitemap definitions go here.
 All sitemap files have to have the ".sitemap" file extension and must follow a special syntax.
 
-Check out the openHAB2 documentation for more details:
+Check out the openHAB documentation for more details:
 http://docs.openhab.org/features/sitemap.html

--- a/distributions/distribution-resources/src/main/resources/conf/sitemaps/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/sitemaps/readme.txt
@@ -1,0 +1,7 @@
+
+openHAB2 conf/sitemaps folder
+
+Your sitemap definitions go here.
+All sitemap files have to have the ".sitemap" file extension and must follow a special syntax.
+
+Check out the openHAB Wiki for more details: https://github.com/openhab/openhab/wiki/Explanation-of-Sitemaps

--- a/distributions/distribution-resources/src/main/resources/conf/things/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/things/readme.txt
@@ -1,5 +1,5 @@
 Your thing definitions go here.
 All thing files have to have the ".things" file extension and must follow a special syntax.
 
-Check out the openHAB2 documentation for more details:
+Check out the openHAB documentation for more details:
 http://docs.openhab.org/configuration/things.html

--- a/distributions/distribution-resources/src/main/resources/conf/things/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/things/readme.txt
@@ -1,7 +1,5 @@
-
-openHAB2 conf/things folder
-
 Your thing definitions go here.
 All thing files have to have the ".things" file extension and must follow a special syntax.
 
-Check out the openHAB2 documentation for more details: http://docs.openhab.org
+Check out the openHAB2 documentation for more details:
+http://docs.openhab.org/configuration/things.html

--- a/distributions/distribution-resources/src/main/resources/conf/things/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/things/readme.txt
@@ -1,0 +1,7 @@
+
+openHAB2 conf/things folder
+
+Your thing definitions go here.
+All thing files have to have the ".things" file extension and must follow a special syntax.
+
+Check out the openHAB2 documentation for more details: http://docs.openhab.org

--- a/distributions/distribution-resources/src/main/resources/conf/transform/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/transform/readme.txt
@@ -1,7 +1,5 @@
-
-openHAB2 conf/transform folder
-
 Transformations like map or jsonpath can utilize configuration files with data definitions.
 These files have their specific file extensions and syntax definition.
 
-Check out the openHAB Wiki for more details: https://github.com/openhab/openhab/wiki/Transformations
+Check out the openHAB2 documentation for more details:
+http://docs.openhab.org/addons/transformations.html

--- a/distributions/distribution-resources/src/main/resources/conf/transform/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/transform/readme.txt
@@ -1,0 +1,7 @@
+
+openHAB2 conf/transform folder
+
+Transformations like map or jsonpath can utilize configuration files with data definitions.
+These files have their specific file extensions and syntax definition.
+
+Check out the openHAB Wiki for more details: https://github.com/openhab/openhab/wiki/Transformations

--- a/distributions/distribution-resources/src/main/resources/conf/transform/readme.txt
+++ b/distributions/distribution-resources/src/main/resources/conf/transform/readme.txt
@@ -1,5 +1,5 @@
 Transformations like map or jsonpath can utilize configuration files with data definitions.
 These files have their specific file extensions and syntax definition.
 
-Check out the openHAB2 documentation for more details:
+Check out the openHAB documentation for more details:
 http://docs.openhab.org/addons/transformations.html


### PR DESCRIPTION
Following up on https://community.openhab.org/t/iconset-where-is-in-oh2/6632/4

Should the readme contain some actual info? Otherwise we could commit .gitkeep files instead!?