### PR TITLE
have events displayed in the console again

### DIFF
--- a/distributions/distribution-resources/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distributions/distribution-resources/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -3,7 +3,7 @@ log4j.rootLogger = WARN, out, osgi:*
 log4j.throwableRenderer=org.apache.log4j.OsgiThrowableRenderer
 
 # openHAB specific logger configuration
-log4j.logger.smarthome.event = INFO, event
+log4j.logger.smarthome.event = INFO, event, osgi:*
 log4j.logger.smarthome.event.ItemStateEvent = ERROR
 log4j.logger.smarthome.event.ThingStatusInfoEvent = ERROR
 log4j.logger.smarthome.event.InboxUpdatedEvent = ERROR


### PR DESCRIPTION
Through #234, event logging disappeared not only from openhab.log, but also from the console.
This PR brings it back in the console.

Signed-off-by: Kai Kreuzer <kai@openhab.org>