### PR TITLE
jdeb tweak: replace "SNAPSHOT" in version numbers with current timestamp

### DIFF
--- a/distributions/pom.xml
+++ b/distributions/pom.xml
@@ -43,6 +43,7 @@
                                 <goal>jdeb</goal>
                             </goals>
                             <configuration>
+                                <snapshotExpand>true</snapshotExpand>
                                 <controlDir>${basedir}/../distribution-resources/src/main/resources/deb/control-runtime</controlDir>
                                 <deb>${basedir}/target/${deb.name}-${project.version}.deb</deb>
                                 <dataSet>


### PR DESCRIPTION
With these changes to the jdeb configuration the deb version numbering is altered in a way that the string "SNAPSHOT" is replaced with the current timestamp. Currently all snapshot debs have the version number 2.0.0~SNAPSHOT this will be changed to e.g. 2.0.0~20160824210122.

This PR should solve the issues reported here: https://community.openhab.org/t/installing-extensions-fails-with-org-osgi-service-resolver-resolutionexception/12298/11