### PR TITLE
Add git files and vim modeline to demo resources

### DIFF
--- a/features/openhab-demo-resources/src/main/resources/.gitattributes
+++ b/features/openhab-demo-resources/src/main/resources/.gitattributes
@@ -1,0 +1,6 @@
+*.items linguist-language=Xtend
+*.persist linguist-language=Xtend
+*.sitemap linguist-language=Xtend
+*.things linguist-language=Xtend
+*.map linguist-language=Xtend
+*.cfg linguist-language=INI

--- a/features/openhab-demo-resources/src/main/resources/.gitignore
+++ b/features/openhab-demo-resources/src/main/resources/.gitignore
@@ -1,0 +1,6 @@
+# This file is only relevant, if you decide to track your configuration in a git repository.
+# If you are going to upload your configuration to GitHub or another public place, be sure to
+# hide your sensitive data, examples may be:
+
+#services/pushover.cfg  # may contain your login credentials
+#things/astro.things    # may contain your physical location

--- a/features/openhab-demo-resources/src/main/resources/items/demo.items
+++ b/features/openhab-demo-resources/src/main/resources/items/demo.items
@@ -4,7 +4,7 @@ Group gC            "Cellar"        <cellar>
 Group Garden        "Garden"        <garden>
 Group Weather       "Weather"       <sun>
 
-Group Status 
+Group Status
 Group Shutters
 
 Group GF_Living     "Living Room"   <video>     (gGF)
@@ -121,3 +121,5 @@ Dimmer Volume                   "Volume [%.1f %%]"
 Number Temperature_Setpoint     "Temperature [%.1f °C]" <temperature>
 Location DemoLocation           "Brandenburg Gate Berlin"
 Number Wifi_Level               "Wifi Level [%d/4]"     <signal>        (FF_Office)
+
+// vim: syntax=Xtend syntax=openhab

--- a/features/openhab-demo-resources/src/main/resources/persistence/logging.persist
+++ b/features/openhab-demo-resources/src/main/resources/persistence/logging.persist
@@ -4,7 +4,7 @@ Strategies {
 	default = everyChange
 }
 
-/* 
+/*
  * Each line in this section defines for which item(s) which strategy(ies) should be applied.
  * You can list single items, use "*" for all items or "groupitem*" for all members of a group
  * item (excl. the group item itself).
@@ -13,3 +13,5 @@ Items {
 	// log all temperatures on every change
 	Temperature* -> "temperatures" : strategy=everyChange
 }
+
+// vim: syntax=Xtend syntax=openhab

--- a/features/openhab-demo-resources/src/main/resources/persistence/rrd4j.persist
+++ b/features/openhab-demo-resources/src/main/resources/persistence/rrd4j.persist
@@ -10,3 +10,5 @@ Items {
 	// let's only store temperature values in rrd
 	Temperature*,Weather_Chart* : strategy = everyMinute, restoreOnStartup
 }
+
+// vim: syntax=Xtend syntax=openhab

--- a/features/openhab-demo-resources/src/main/resources/rules/demo.rules
+++ b/features/openhab-demo-resources/src/main/resources/rules/demo.rules
@@ -1,8 +1,8 @@
 var Timer timer = null
 
 /**
- * This is a demo rule which simulates a real dimmer by reacting to increase/decrease commands 
- * and posting an updated state on the bus 
+ * This is a demo rule which simulates a real dimmer by reacting to increase/decrease commands
+ * and posting an updated state on the bus
  */
 rule "Dimmed Light"
 	when
@@ -10,7 +10,7 @@ rule "Dimmed Light"
 	then
         if ((receivedCommand==INCREASE) || (receivedCommand==DECREASE)) {
     		var Number percent = 0
-    		if(DimmedLight.state instanceof DecimalType) percent = DimmedLight.state as DecimalType 
+    		if(DimmedLight.state instanceof DecimalType) percent = DimmedLight.state as DecimalType
     			
     		if(receivedCommand==INCREASE) percent = percent + 5
     		if(receivedCommand==DECREASE) percent = percent - 5
@@ -40,7 +40,7 @@ then
         if(timer!=null) {
             timer.cancel
             timer = null
-        }   
+        }
     }
 end
 
@@ -57,7 +57,7 @@ rule "Initialize light states"
 end
 
 rule "Initialize heating states"
-	when 
+	when
 		System started
 	then
 		Heating?.members.forEach(heating|
@@ -67,7 +67,7 @@ rule "Initialize heating states"
 end
 
 rule "Initialize contact states"
-	when 
+	when
 		System started
 	then
 		Windows?.members.forEach(window|
@@ -76,14 +76,14 @@ rule "Initialize contact states"
 end
 
 rule "Initialize Location"
-	when 
+	when
 		System started
 	then
 		DemoLocation.postUpdate(new PointType("52.5200066,13.4049540"))
 end
 
 rule "Set random room temperatures"
-	when 
+	when
 		System started or
 		Time cron "0 0/5 * * * ?"
 	then
@@ -97,7 +97,7 @@ when
 	Item Weather_Temperature changed or
 	Time cron "0 0 0 * * ?" or
 	System started
-then	
+then
 	postUpdate(Weather_Temp_Max, Weather_Temperature.maximumSince(now.withTimeAtStartOfDay).state)
 	postUpdate(Weather_Temp_Min, Weather_Temperature.minimumSince(now.withTimeAtStartOfDay).state)
 end
@@ -111,9 +111,11 @@ then
 end
 
 rule "Set random wifi variations"
-    when 
+    when
         System started or
         Time cron "/20 * * * * ?"
     then
         postUpdate(Wifi_Level, (Math::random * 4.0).intValue)
 end
+
+// vim: syntax=Xtend syntax=openhab

--- a/features/openhab-demo-resources/src/main/resources/scripts/demo.script
+++ b/features/openhab-demo-resources/src/main/resources/scripts/demo.script
@@ -1,1 +1,3 @@
 say("Demo script has been called!")
+
+// vim: syntax=Xtend syntax=openhab

--- a/features/openhab-demo-resources/src/main/resources/sitemaps/demo.sitemap
+++ b/features/openhab-demo-resources/src/main/resources/sitemaps/demo.sitemap
@@ -3,8 +3,8 @@ sitemap demo label="Main Menu"
 	Frame {
 		Group item=gFF label="First Floor" icon="firstfloor"
 		Group item=gGF label="Ground Floor" icon="groundfloor"
-		Group item=gC label="Cellar" icon="cellar"	
-		Group item=Garden icon="garden" 
+		Group item=gC label="Cellar" icon="cellar"
+		Group item=Garden icon="garden"
 	}
 	Frame label="Weather" {
 		Text item=Weather_Temperature valuecolor=[Weather_LastUpdate=="NULL"="lightgray",Weather_LastUpdate>90="lightgray",>25="orange",>15="green",>5="orange",<=5="blue"] {
@@ -73,3 +73,5 @@ sitemap demo label="Main Menu"
 		}
 	}
 }
+
+// vim: syntax=Xtend syntax=openhab

--- a/features/openhab-demo-resources/src/main/resources/things/demo.things
+++ b/features/openhab-demo-resources/src/main/resources/things/demo.things
@@ -2,3 +2,5 @@ yahooweather:weather:berlin [ location=638242 ]
 astro:sun:home   [ geolocation="52.5200066,13.4049540", interval=60 ]
 astro:moon:home  [ geolocation="52.5200066,13.4049540", interval=60 ]
 ntp:ntp:demo [ hostname="nl.pool.ntp.org", refreshInterval=60, refreshNtp=30 ]
+
+// vim: syntax=Xtend syntax=openhab


### PR DESCRIPTION
Regarding the demo package: The following additions make tracking of a users configuration in a git/GitHub repository easier.

**.gitattributes**
* this file will tell GitHub which files have to be counted as which language in statistics: https://github.com/github/linguist#using-gitattributes

**.gitignore**
* providing a default gitignore with commented examples

**vim modeline**
* in accordance with https://github.com/github/linguist#using-emacs-or-vim-modelines
* By adding `// vim: syntax=Xtend` at the end of each file, GitHub is able to syntax highlight openHAB files.
* Compare [before](https://github.com/openhab/openhab-distro/blob/master/features/openhab-demo-resources/src/main/resources/rules/demo.rules) and [after](https://github.com/ThomDietrich/openhab-distro/blob/demo-syntax-hl/features/openhab-demo-resources/src/main/resources/rules/demo.rules)
* The extension `// vim: syntax=Xtend syntax=openhab` will additionally make this compatible with https://github.com/cyberkov/openhab-vim