### PR TITLE
upgrade apt-repo maven plugin to 0.3.0

### DIFF
--- a/distributions/openhab-offline/pom.xml
+++ b/distributions/openhab-offline/pom.xml
@@ -165,15 +165,6 @@
             <plugin>
                 <artifactId>apt-repo</artifactId>
                 <groupId>org.m1theo</groupId>
-                <version>0.2.3</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>apt-repo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
       </build>

--- a/distributions/openhab-online/pom.xml
+++ b/distributions/openhab-online/pom.xml
@@ -158,15 +158,6 @@
             <plugin>
                 <artifactId>apt-repo</artifactId>
                 <groupId>org.m1theo</groupId>
-                <version>0.2.3</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>apt-repo</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/distributions/pom.xml
+++ b/distributions/pom.xml
@@ -185,6 +185,19 @@
                         </execution>
                     </executions>
                 </plugin>
+            <plugin>
+                <artifactId>apt-repo</artifactId>
+                <groupId>org.m1theo</groupId>
+                <version>0.3.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>apt-repo</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
upgrade apt-repo maven plugin to 0.3.0 in preparation of signing the snapshot releases.