### PR TITLE
Replace patched pax-web-jetty with dynamic patching.

### DIFF
--- a/distributions/openhab-offline/pom.xml
+++ b/distributions/openhab-offline/pom.xml
@@ -50,16 +50,27 @@
             <type>xml</type>
             <scope>runtime</scope>
         </dependency>
-        <!-- Temporary patch for https://github.com/openhab/openhab-distro/issues/10 -->
-        <dependency>
-            <groupId>org.openhab.distro.deps</groupId>
-            <artifactId>pax-web-jetty</artifactId>
-            <version>4.2.4</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>1.5.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.openhab.util</groupId>
+                            <artifactId>pax-web-patch</artifactId>
+                            <version>1.0.0</version>
+                        </dependency>  
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <resources>
             <!-- add shared distribution resources -->
             <resource>
@@ -136,6 +147,25 @@
                     </bootFeatures>
                     <archiveZip>false</archiveZip>
                     <archiveTarGz>false</archiveTarGz>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>org.openhab.patch.ClassPathUtilPatcher</mainClass>
+                    <arguments>
+                        <argument>${project.basedir}/target/assembly/system/org/ops4j/pax/web/pax-web-api</argument>
+                    </arguments>
+                    <includePluginDependencies>True</includePluginDependencies>
                 </configuration>
             </plugin>
             <plugin>

--- a/distributions/openhab-offline/src/main/descriptors/archive.xml
+++ b/distributions/openhab-offline/src/main/descriptors/archive.xml
@@ -49,9 +49,6 @@
                 <include>lib/**</include>
                 <include>system/**</include>
             </includes>
-            <excludes>
-                <exclude>system/**/pax-web-jetty*.jar</exclude>
-            </excludes>
         </fileSet>
 
         <!-- KARAF_DATA -->
@@ -95,12 +92,6 @@
             <outputDirectory></outputDirectory>
             <fileMode>0644</fileMode>
             <lineEnding>windows</lineEnding>
-        </file>      
-        <!-- add patch for https://github.com/openhab/openhab-distro/issues/10 -->
-        <file>
-            <source>target/assembly/system/org/openhab/distro/deps/pax-web-jetty/4.2.4/pax-web-jetty-4.2.4.jar</source>
-            <outputDirectory>runtime/karaf/system/org/ops4j/pax/web/pax-web-jetty/4.2.4/</outputDirectory>
-            <destName>pax-web-jetty-4.2.4.jar</destName>
         </file>
     </files>
 

--- a/distributions/openhab-online/pom.xml
+++ b/distributions/openhab-online/pom.xml
@@ -44,16 +44,27 @@
             <type>xml</type>
             <scope>runtime</scope>
         </dependency>
-        <!-- Temporary patch for https://github.com/openhab/openhab-distro/issues/10 -->
-        <dependency>
-            <groupId>org.openhab.distro.deps</groupId>
-            <artifactId>pax-web-jetty</artifactId>
-            <version>4.2.4</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>1.5.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.openhab.util</groupId>
+                            <artifactId>pax-web-patch</artifactId>
+                            <version>1.0.0</version>
+                        </dependency>  
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <resources>
             <!-- add shared distribution resources -->
             <resource>
@@ -129,6 +140,25 @@
                     </bootFeatures>
                     <archiveZip>false</archiveZip>
                     <archiveTarGz>false</archiveTarGz>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>org.openhab.patch.ClassPathUtilPatcher</mainClass>
+                    <arguments>
+                        <argument>${project.basedir}/target/assembly/system/org/ops4j/pax/web/pax-web-api</argument>
+                    </arguments>
+                    <includePluginDependencies>True</includePluginDependencies>
                 </configuration>
             </plugin>
             <plugin>

--- a/distributions/openhab-online/src/main/descriptors/archive.xml
+++ b/distributions/openhab-online/src/main/descriptors/archive.xml
@@ -49,9 +49,6 @@
                 <include>lib/**</include>
                 <include>system/**</include>
             </includes>
-            <excludes>
-                <exclude>pax-web-jetty*.jar</exclude>
-            </excludes>
         </fileSet>
 
         <!-- KARAF_DATA -->
@@ -95,12 +92,6 @@
             <outputDirectory></outputDirectory>
             <fileMode>0644</fileMode>
             <lineEnding>windows</lineEnding>
-        </file>
-        <!-- add patch for https://github.com/openhab/openhab-distro/issues/10 -->
-        <file>
-            <source>target/assembly/system/org/openhab/distro/deps/pax-web-jetty/4.2.4/pax-web-jetty-4.2.4.jar</source>
-            <outputDirectory>runtime/karaf/system/org/ops4j/pax/web/pax-web-jetty/4.2.4/</outputDirectory>
-            <destName>pax-web-jetty-4.2.4.jar</destName>
         </file>
     </files>
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,21 @@
         </plugins>
     </build>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>openhab-bintray</id>
+            <name>Bintray Repository for openHAB</name>
+            <url>https://dl.bintray.com/openhab/mvn/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <repositories>
        <!-- ESH releases -->
         <repository>


### PR DESCRIPTION
Rather than having to manually patch pax-web-jetty for each version to avoid it from performing bundle scans, this change now applies to patch directly to whatever version of pax-web is included in the build. As requested in #18 .