### PR TITLE
ensure removeCache returns true

### DIFF
--- a/distributions/distribution-resources/src/main/resources/deb/control-runtime/postrm
+++ b/distributions/distribution-resources/src/main/resources/deb/control-runtime/postrm
@@ -16,6 +16,7 @@ removeOpenHABInit() {
 removeCache(){
     rm -rf /var/lib/openhab2/cache
     rm -rf /var/lib/openhab2/tmp
+	true
 }
 
 case "$1" in

--- a/distributions/distribution-resources/src/main/resources/deb/control-runtime/preinst
+++ b/distributions/distribution-resources/src/main/resources/deb/control-runtime/preinst
@@ -8,6 +8,7 @@ UD_TMP=/var/lib/openhab2/tmp
 removeCache(){
     [ -d ${UD_CACHE} ] && rm -rf ${UD_CACHE}
     [ -d ${UD_TMP} ] && rm -rf ${UD_TMP}
+	true
 }
 
 case "$1" in


### PR DESCRIPTION
This is the fix for #301 which is a regression introduced with #286.
New installations will fail because "set -e" is enabled and /var/lib/openhab2/tmp don't exist. Upgrades are not affected.
It will be good to have this merged soon because new snapshot installations are impossible.

