### PR TITLE
Fixed Debian Package Paths

### DIFF
--- a/distributions/distribution-resources/src/main/resources/deb/bin/oh2_dir_layout
+++ b/distributions/distribution-resources/src/main/resources/deb/bin/oh2_dir_layout
@@ -3,16 +3,13 @@
 # DIRNAME is the directory of karaf, setenv, etc.
 (unset CDPATH) >/dev/null 2>&1 && unset CDPATH
 
-export OPENHAB_HOME=`cd "$DIRNAME/../../.."; pwd`
+export OPENHAB_HOME=`cd "$DIRNAME/../.."; pwd`
 export OPENHAB_CONF="/etc/openhab2"
 export OPENHAB_RUNTIME="${OPENHAB_HOME}/runtime"
 export OPENHAB_USERDATA="/var/lib/openhab2"
 export OPENHAB_LOGDIR="/var/log/openhab2"
 
-export KARAF_HOME="${OPENHAB_RUNTIME}/karaf"
+export KARAF_HOME="${OPENHAB_RUNTIME}"
 export KARAF_DATA="${OPENHAB_USERDATA}"
 export KARAF_BASE="${OPENHAB_USERDATA}"
-export KARAF_ETC="${OPENHAB_RUNTIME}/karaf/etc"
-
-
-
+export KARAF_ETC="${OPENHAB_USERDATA}/etc"

--- a/distributions/distribution-resources/src/main/resources/deb/etc/init.d/openhab2
+++ b/distributions/distribution-resources/src/main/resources/deb/etc/init.d/openhab2
@@ -76,7 +76,7 @@ case "$1" in
         log_daemon_msg "Starting $DESC" "$NAME"
         #${OPENHAB_INST_DIR}/bin/setpermissions.sh > /dev/null
         if start-stop-daemon --start --quiet --pidfile $PIDFILE -c "${USER_AND_GROUP}" --umask 002 --background --make-pidfile --chdir ${OPENHAB_DIR} \
-                --oknodo --exec /usr/share/openhab2/runtime/karaf/bin/start
+                --oknodo --exec /usr/share/openhab2/runtime/bin/start
         then
             log_end_msg 0
         else
@@ -85,7 +85,7 @@ case "$1" in
         ;;
   stop)
         log_daemon_msg "Stopping $DESC" "$NAME"
-        if /usr/share/openhab2/runtime/karaf/bin/stop
+        if /usr/share/openhab2/runtime/bin/stop
         then
             rm -f $PIDFILE
             log_end_msg 0
@@ -94,13 +94,13 @@ case "$1" in
         fi
         ;;
   status)
-        /usr/share/openhab2/runtime/karaf/bin/status
+        /usr/share/openhab2/runtime/bin/status
         ;;
   restart|force-reload)
         log_daemon_msg "Restarting $DESC" "$NAME"
-        if /usr/share/openhab2/runtime/karaf/bin/stop
+        if /usr/share/openhab2/runtime/bin/stop
         then
-            if /usr/share/openhab2/runtime/karaf/bin/start
+            if /usr/share/openhab2/runtime/bin/start
             then
                 log_end_msg 0
             else

--- a/distributions/distribution-resources/src/main/resources/deb/systemd/openhab2.service
+++ b/distributions/distribution-resources/src/main/resources/deb/systemd/openhab2.service
@@ -13,7 +13,7 @@ WorkingDirectory=/usr/share/openhab2
 #PermissionsStartOnly=true
 #ExecStartPre=/usr/share/openhab/bin/setpermissions.sh
 ExecStart=/usr/share/openhab2/start.sh server
-ExecStop=/usr/share/openhab2/runtime/karaf/bin/stop
+ExecStop=/usr/share/openhab2/runtime/bin/stop
 # Shutdown delay in seconds, before process is tried to be killed with KILL (if configured)
 TimeoutStopSec=120
 Restart=on-failure

--- a/distributions/pom.xml
+++ b/distributions/pom.xml
@@ -122,7 +122,7 @@
                                     <data>
                                         <src>${basedir}/target/${deb.srcarchive}</src>
                                         <type>archive</type>
-                                        <excludes>conf/**,userdata/**,runtime/karaf/bin/oh2_dir_layout,start.bat,start_debug.bat</excludes>
+                                        <excludes>conf/**,userdata/**,runtime/bin/oh2_dir_layout,start.bat,start_debug.bat</excludes>
                                         <mapper>
                                             <type>perm</type>
                                             <prefix>/usr/share/openhab2</prefix>
@@ -162,7 +162,7 @@
                                         <type>file</type>
                                         <mapper>
                                             <type>perm</type>
-                                            <prefix>/usr/share/openhab2/runtime/karaf/bin</prefix>
+                                            <prefix>/usr/share/openhab2/runtime/bin</prefix>
                                             <filemode>755</filemode>
                                             <user>root</user>
                                             <group>root</group>


### PR DESCRIPTION
Installations or upgrades should at least not fail after #318 with this change.

I do get a large number of warnings and errors on upgrade to this package, but all seems fine after waiting and restarting the service one more time and everything looks like it's where it is supposed to be.

Here are the [online](https://dl.dropboxusercontent.com/u/6184504/deb%20builds/openhab2-online-2.0.0-SNAPSHOT.deb) and [offline](https://dl.dropboxusercontent.com/u/6184504/deb%20builds/openhab2-offline-2.0.0-SNAPSHOT.deb) packages for those who want to test.

Signed-of-by: Ben Clark <ben@benjyc.uk>