### PR TITLE
Recreate /var/lib/openhab2/tmp on upgrade

### DIFF
--- a/distributions/distribution-resources/src/main/resources/deb/control-runtime/postinst
+++ b/distributions/distribution-resources/src/main/resources/deb/control-runtime/postinst
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+UD_TMP=/var/lib/openhab2/tmp
+
 set -e
 if [ x"${OH_DOCKER_INSTALLATION}" != x ]; then
     echo "docker installation \"${OH_DOCKER_INSTALLATION}\""
@@ -39,6 +41,14 @@ case "$1" in
 			fi
 		else
 			# this is an upgrade
+			OH_USER=openhab
+			OH_GROUP=openhab
+			if [ x"${USER_AND_GROUP}" != x ]; then
+				OH_USER=`echo ${USER_AND_GROUP} | cut -d ":" -f 1`
+				OH_GROUP=`echo ${USER_AND_GROUP} | cut -d ":" -f 2`
+			fi
+			mkdir -p $UD_TMP
+			chown -R "$OH_USER:$OH_GROUP" $UD_TMP
 			startOpenHAB
 		fi
 		;;


### PR DESCRIPTION
the removeCache function removes the tmp folder on each upgrade, but for some reason openhab is unable to create the folder again on install.

Workaround: Run a simple script to make the directory and set the appropriate owner before running openhab.

Fixes #366 

Signed-off-by: Ben Clark <ben@benjyc.uk>