### PR TITLE
Switch karaf remote console key to PEM format

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/org.apache.karaf.shell.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.apache.karaf.shell.cfg
@@ -48,7 +48,7 @@ hostKey = ${karaf.etc}/host.key
 # The format used for hostKey.
 # Possible values are simple (Karaf internal), or PEM (OpenSSH format)
 #
-hostKeyFormat = simple
+hostKeyFormat = PEM
 
 #
 # Role name used for SSH access authorization


### PR DESCRIPTION
In case https://github.com/openhab/openhab-linuxpkg/issues/15 gets implemented at a later point, this change would be needed. As the karaf key of users gets changed, triggered by this PR, I want to propose this for 2.0 RC/GA. The key format switch doesn't seem to change any behavior as we know it.

Signed-off-by: Thomas Dietrich <thomas.dietrich@tu-ilmenau.de> (github: ThomDietrich)