### PR TITLE
Consider OPENHAB_* on startup. Closes #408

### DIFF
--- a/distributions/openhab/src/main/resources/bin/oh2_dir_layout
+++ b/distributions/openhab/src/main/resources/bin/oh2_dir_layout
@@ -4,13 +4,25 @@
 (unset CDPATH) >/dev/null 2>&1 && unset CDPATH
 
 export OPENHAB_HOME=`cd "$DIRNAME/../.."; pwd`
-export OPENHAB_CONF="${OPENHAB_HOME}/conf"
-export OPENHAB_RUNTIME="${OPENHAB_HOME}/runtime"
-export OPENHAB_USERDATA="${OPENHAB_HOME}/userdata"
-export OPENHAB_LOGDIR="${OPENHAB_USERDATA}/logs"
+
+if [ -z ${OPENHAB_CONF} ]; then
+    export OPENHAB_CONF="${OPENHAB_HOME}/conf"
+fi
+
+if [ -z ${OPENHAB_RUNTIME} ]; then
+    export OPENHAB_RUNTIME="${OPENHAB_HOME}/runtime"
+fi
+
+if [ -z ${OPENHAB_USERDATA} ]; then
+    export OPENHAB_USERDATA="${OPENHAB_HOME}/userdata"
+fi
+
+if [ -z ${OPENHAB_LOGDIR} ]; then
+    export OPENHAB_LOGDIR="${OPENHAB_USERDATA}/logs"
+fi
+
 
 export KARAF_HOME="${OPENHAB_RUNTIME}"
 export KARAF_DATA="${OPENHAB_USERDATA}"
 export KARAF_BASE="${OPENHAB_USERDATA}"
 export KARAF_ETC="${OPENHAB_USERDATA}/etc"
-

--- a/distributions/openhab/src/main/resources/bin/oh2_dir_layout.bat
+++ b/distributions/openhab/src/main/resources/bin/oh2_dir_layout.bat
@@ -2,10 +2,28 @@ rem DIRNAME is the directory of karaf, setenv, etc.
 CALL :removeSpacesFromPath "%DIRNAME%..\.."
 
 set OPENHAB_HOME=%RETVAL%
+
+:check_conf
+IF NOT [%OPENHAB_CONF%] == [] GOTO :conf_set
 set OPENHAB_CONF=%OPENHAB_HOME%\conf
+:conf_set
+
+:check_runtime
+IF NOT [%OPENHAB_RUNTIME%] == [] GOTO :runtime_set
 set OPENHAB_RUNTIME=%OPENHAB_HOME%\runtime
+:runtime_set
+
+:check_userdata
+IF NOT [%OPENHAB_USERDATA%] == [] GOTO :userdata_set
 set OPENHAB_USERDATA=%OPENHAB_HOME%\userdata
+:userdata_set
+
+:check_logs
+IF NOT [%OPENHAB_LOGDIR%] == [] GOTO :logs_set
 set OPENHAB_LOGDIR=%OPENHAB_USERDATA%\logs
+:logs_set
+
+
 set KARAF_HOME=%OPENHAB_RUNTIME%
 set KARAF_DATA=%OPENHAB_USERDATA%
 set KARAF_BASE=%OPENHAB_USERDATA%


### PR DESCRIPTION
if  OPENHAB_CONF, OPENHAB_RUNTIME, OPENHAB_USERDATA or OPENHAB_LOGDIR are set upon start their values are now used instead of defaults.

Closes #408