### PR TITLE
Update jetty.xml

### DIFF
--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -204,4 +204,8 @@
 			</New>
 		</Arg>
 	</Call>
+	<Call name="setAttribute">
+                <Arg>org.eclipse.jetty.server.Request.maxFormContentSize</Arg>
+                <Arg>300000</Arg>
+	</Call>
 </Configure>


### PR DESCRIPTION
Increase the "maxFormContentSize" from the default value 200000 to 300000. This solves a saving error by using the php-editor of CometVisu, if the default implemented transmitting size value is overrun.