### PR TITLE
update and rename link to openhab2-addons

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ When no solution was found, use the table below to determine where your issue sh
 Issue | Where to report
 ------|----------------
 Problems and feature requests for openHAB 1 addons | [openHAB] (https://github.com/openhab/openhab/issues)
-Problems and feature requests for openHAB 2 addons | [openHAB2] (https://github.com/openhab/openhab2/issues)
+Problems and feature requests for openHAB 2 addons | [openHAB2-addons] (https://github.com/openhab/openhab2-addons/issues)
 Issues related to the runtime environment, IDE and packaging | [openHAB-distro] (https://github.com/openhab/openhab-distro/issues)
 Issues related to the core openHAB bundles that are not from Eclipse SmartHome | [openHAB-core] (https://github.com/kaikreuzer/openhab-core/issues)
 Issues related to Eclipse SmartHome addons and core runtime | [Eclipse SmartHome] (https://github.com/eclipse/smarthome/issues)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ When no solution was found, use the table below to determine where your issue sh
 
 Issue | Where to report
 ------|----------------
-Problems and feature requests for openHAB 1 addons | [openHAB] (https://github.com/openhab/openhab/issues)
+Problems and feature requests for openHAB 1 addons | [openHAB1-addons] (https://github.com/openhab/openhab1-addons/issues)
 Problems and feature requests for openHAB 2 addons | [openHAB2-addons] (https://github.com/openhab/openhab2-addons/issues)
 Issues related to the runtime environment, IDE and packaging | [openHAB-distro] (https://github.com/openhab/openhab-distro/issues)
 Issues related to the core openHAB bundles that are not from Eclipse SmartHome | [openHAB-core] (https://github.com/kaikreuzer/openhab-core/issues)


### PR DESCRIPTION
the old link pointed to https://github.com/openhab/openhab2/issues.
That worked, but the repository was renamed.

Signed-off-by: Christoph Wempe cw-git@wempe.net (github: CWempe)