### PR TITLE
Change gnu to posix tar in pom.xml to support large UID/GID

### DIFF
--- a/distributions/online-repo/pom.xml
+++ b/distributions/online-repo/pom.xml
@@ -65,7 +65,7 @@
 								<descriptor>src/main/descriptors/archive.xml</descriptor>
 							</descriptors>
 							<appendAssemblyId>false</appendAssemblyId>
-							<tarLongFileMode>gnu</tarLongFileMode>
+							<tarLongFileMode>posix</tarLongFileMode>
 						</configuration>
 					</execution>
 				</executions>

--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -170,7 +170,7 @@
                                 <descriptor>src/main/descriptors/archive.xml</descriptor>
                             </descriptors>
                             <appendAssemblyId>false</appendAssemblyId>
-                            <tarLongFileMode>gnu</tarLongFileMode>
+                            <tarLongFileMode>posix</tarLongFileMode>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
In certain cases the UID/GID of the user building openHAB
may exceed the values permitted by gnu tar.

Resolves https://github.com/openhab/openhab-distro/issues/433

Resolution of build failure as per directions given by
https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#tarFileModes

Signed-off-by: Jeff Kletsky <git-commits@allycomm.com> (github: jeffsf)

As per http://docs.openhab.org/developers/contributing/contributing.html
retrieved on 2017-03-16