### PR TITLE
Add Require statement

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.ps1
+++ b/distributions/openhab/src/main/resources/bin/update.ps1
@@ -1,4 +1,5 @@
-﻿Function Update-openHAB {
+#Requires -Version 5.0
+Function Update-openHAB {
     <#
     .SYNOPSIS
     Updates openHAB to the latest version.


### PR DESCRIPTION
Expand-Archive requires PowerShell v5.
The Require statement will prevent the script from running on older versions and causing broken updates.