### PR TITLE
#533: Add sshHost parameter to services/runtime.cfg

### DIFF
--- a/distributions/openhab/src/main/resources/conf/services/runtime.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/runtime.cfg
@@ -48,6 +48,18 @@
 
 ################ MISCELLANOUS ####################
 
+# The karaf sshHost parameter configures the bind address for the ssh login to karaf.
+# Default is 127.0.0.1 (localhost), so it is only possible to login from the local machine.
+#
+# Setting this to the address of another network interfaces will allow login from this network.
+# Setting this to 0.0.0.0 will allow login from all network interfaces.
+#
+# !!! Security warning !!!
+#   Remember to change default login/password, if you allow external login.
+#   See http://docs.openhab.org/administration/console.html for details.
+#
+#org.apache.karaf.shell:sshHost = 0.0.0.0
+
 # Setting this to true will automatically approve all inbox entries and create Things for them,
 # so that they are immediately available in the system (default is false)
 #


### PR DESCRIPTION
As suggested in #533 I added the org.apache.karaf.shell:sshHost parameter to services/runtime.cfg with an explanation.