### PR TITLE
don't use same feature repo content twice

### DIFF
--- a/distributions/openhab-addons/pom.xml
+++ b/distributions/openhab-addons/pom.xml
@@ -12,13 +12,41 @@
     <artifactId>openhab-addons</artifactId>
     <packaging>kar</packaging>
 
-    <name>openHAB Add-ons KAR</name>
+    <name>openHAB Add-ons Aggregator</name>
 
     <dependencies>
+        <dependency>
+            <groupId>org.eclipse.smarthome</groupId>
+            <artifactId>esh-ext</artifactId>
+            <version>${esh.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
+        <dependency>
+            <groupId>org.openhab.distro</groupId>
+            <artifactId>addons-esh</artifactId>
+            <version>${project.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
         <dependency>
             <groupId>org.openhab.distro</groupId>
             <artifactId>addons</artifactId>
             <version>${project.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
+        <dependency>
+            <groupId>org.openhab.addons</groupId>
+            <artifactId>openhab2-addons</artifactId>
+            <version>${oh2.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
+        <dependency>
+            <groupId>org.openhab.addons</groupId>
+            <artifactId>openhab-addons</artifactId>
+            <version>${oh1.version}</version>
             <classifier>features</classifier>
             <type>xml</type>
         </dependency>
@@ -32,6 +60,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <startLevel>80</startLevel>
+                    <enableGeneration>true</enableGeneration>
                     <aggregateFeatures>true</aggregateFeatures>
                     <!--  <resolver>(obr)</resolver> -->
                     <checkDependencyChange>true</checkDependencyChange>
@@ -46,6 +75,15 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>generate-features-file</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>features-generate-descriptor</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>org.openhab.distro</groupId>
-            <artifactId>addons</artifactId>
+            <artifactId>openhab-addons</artifactId>
             <version>${project.version}</version>
             <classifier>features</classifier>
             <type>xml</type>

--- a/features/addons/pom.xml
+++ b/features/addons/pom.xml
@@ -13,38 +13,8 @@
 	<packaging>feature</packaging>
 
 	<name>openHAB Add-ons</name>
+	<description>These are 2.x add-ons in separate repositories (which do not have their own Karaf feature defined).</description>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.smarthome</groupId>
-			<artifactId>esh-ext</artifactId>
-			<version>${esh.version}</version>
-			<classifier>features</classifier>
-			<type>xml</type>
-		</dependency>
-		<dependency>
-			<groupId>org.openhab.distro</groupId>
-			<artifactId>addons-esh</artifactId>
-			<version>${project.version}</version>
-			<classifier>features</classifier>
-			<type>xml</type>
-		</dependency>
-		<dependency>
-			<groupId>org.openhab.addons</groupId>
-			<artifactId>openhab2-addons</artifactId>
-			<version>${oh2.version}</version>
-			<classifier>features</classifier>
-			<type>xml</type>
-		</dependency>
-		<dependency>
-			<groupId>org.openhab.addons</groupId>
-			<artifactId>openhab-addons</artifactId>
-			<version>${oh1.version}</version>
-			<classifier>features</classifier>
-			<type>xml</type>
-		</dependency>
-	</dependencies>
-	
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
If the addon KAR file is used there exist two different feature repo
that contains the same content. So every feature exist twice.
This is caused because of different GAV for the same XML.
The one feature repo is created by the feature packaging and the other
one is created by the KAR packaging.
The KAR packaging already included also the feature packaging, so it
should be done only once.

As we must not break existing installations we need to keep the GAV of
the online addons.

Fixes: https://github.com/openhab/openhab-distro/issues/519