### PR TITLE
Automatically calculate online.repo+pax url suffix+build number depending whether there is a releasebuild or not

### DIFF
--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -95,6 +95,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>2.6</version>
+                <configuration>
+                  <escapeString>\</escapeString>
+                </configuration>
                 <executions>
                     <execution>
                         <id>process-resources</id>

--- a/distributions/openhab/src/main/filtered-resources/userdata/etc/org.ops4j.pax.url.mvn.cfg
+++ b/distributions/openhab/src/main/filtered-resources/userdata/etc/org.ops4j.pax.url.mvn.cfg
@@ -77,4 +77,4 @@ org.ops4j.pax.url.mvn.defaultRepositories=\
 # This contains the openhab, smart home and default repositories.
 #
 org.ops4j.pax.url.mvn.repositories= \
-	${online.repo}@id=openhab@snapshots
+	${online.repo}\@id=openhab${pax.url.suffix}

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         </snapshotRepository>
     </distributionManagement>
 
-    <properties>        
+    <properties>
         <online.repo.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</online.repo.version>        
 
         <ohc.version>2.2.0-SNAPSHOT</ohc.version>
@@ -223,6 +223,7 @@
             <properties>
                 <build.number>- local build -</build.number>
                 <online.repo>https://openhab.jfrog.io/openhab/online-repo-snapshot/${online.repo.version}</online.repo>
+                <pax.url.suffix>@snapshots</pax.url.suffix>
             </properties>
         </profile>
         <profile>
@@ -235,6 +236,7 @@
             <properties>
                 <build.number>- release build -</build.number>
                 <online.repo>https://dl.bintray.com/openhab/mvn/online-repo/${online.repo.version}</online.repo>
+                <pax.url.suffix/>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
                 </property>
             </activation>
             <properties>
-                <build.number>- release build -</build.number>
+                <build.number>Release Build</build.number>
                 <online.repo>https://dl.bintray.com/openhab/mvn/online-repo/${online.repo.version}</online.repo>
                 <pax.url.suffix/>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,8 @@
         </snapshotRepository>
     </distributionManagement>
 
-    <properties>
-        <build.number>- local build -</build.number>
-        <online.repo.version>2.2</online.repo.version>
-        <online.repo>https://openhab.jfrog.io/openhab/online-repo-snapshot/${online.repo.version}</online.repo>
-        <!-- repo for releases: https://dl.bintray.com/openhab/mvn/online-repo/${online.repo.version} -->
+    <properties>        
+        <online.repo.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</online.repo.version>        
 
         <ohc.version>2.2.0-SNAPSHOT</ohc.version>
         <oh2.version>2.2.0-SNAPSHOT</oh2.version>
@@ -101,13 +98,23 @@
                         <target>${maven.compiler.target}</target>
                     </configuration>
                 </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>${build.helper.maven.plugin.version}</version>
-                </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${build.helper.maven.plugin.version}</version>
+                <executions>
+                  <execution>
+                    <id>parse-version</id>
+                    <goals>
+                      <goal>parse-version</goal>
+                    </goals>
+                  </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <pluginRepositories>
@@ -205,6 +212,30 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>snapshotbuild</id>
+            <activation>
+                <property>
+                    <name>!release</name>
+                </property>
+            </activation>
+            <properties>
+                <build.number>- local build -</build.number>
+                <online.repo>https://openhab.jfrog.io/openhab/online-repo-snapshot/${online.repo.version}</online.repo>
+            </properties>
+        </profile>
+        <profile>
+            <id>releasebuild</id>
+            <activation>
+                <property>
+                    <name>release</name>
+                </property>
+            </activation>
+            <properties>
+                <build.number>- release build -</build.number>
+                <online.repo>https://dl.bintray.com/openhab/mvn/online-repo/${online.repo.version}</online.repo>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
@kaikreuzer: Unfortunately, for those properties the existing property updating mechanism cannot be used as it just works for (already released) versions. To not have multiple property updating mechanisms, I'd suggest to automatically calculate those properties. "Release properties" will be used when providing `-Drelease` while building.

Signed-off-by: Patrick Fink <mail@pfink.de>