### PR TITLE
increase thread pool sizes

### DIFF
--- a/distributions/openhab/src/main/resources/runtime/services.cfg
+++ b/distributions/openhab/src/main/resources/runtime/services.cfg
@@ -9,6 +9,6 @@ org.eclipse.smarthome.folder:persistence=persist
 org.eclipse.smarthome.folder:things=things
 
 # Configuration of thread pool sizes
-org.eclipse.smarthome.threadpool:thingHandler=3
-org.eclipse.smarthome.threadpool:discovery=3
-org.eclipse.smarthome.threadpool:safeCall=3
+org.eclipse.smarthome.threadpool:thingHandler=5
+org.eclipse.smarthome.threadpool:discovery=5
+org.eclipse.smarthome.threadpool:safeCall=10


### PR DESCRIPTION
Seeing [errors like this](https://community.openhab.org/t/error-freezes-openhab/36839/9), I very much assume that our safe caller thread pool is far too small - increasing the pool size should hopefully resolve such issues.

Signed-off-by: Kai Kreuzer <kai@openhab.org>