### PR TITLE
removed unnecessary p2 repos that only cause log warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,20 +175,6 @@
             </snapshots>
         </repository>
 
-        <!-- SmartHome p2 repository -->
-        <repository>
-            <id>p2-smarthome</id>
-            <url>https://openhab.jfrog.io/openhab/eclipse-smarthome-stable</url>
-            <layout>p2</layout>
-        </repository>
-
-        <!-- openHAB dependencies p2 repository -->
-        <repository>
-            <id>p2-openhab-deps-repo</id>
-            <url>https://dl.bintray.com/openhab/p2/openhab-deps-repo/${ohdr.version}</url>
-            <layout>p2</layout>
-        </repository>
-
     </repositories>
 
     <profiles>


### PR DESCRIPTION
The build shows hundreds of warnings like:
```
[WARNING] Could not transfer metadata org.openhab.core:org.openhab.ui.dashboard:2.2.0-SNAPSHOT/maven-metadata.xml from/to p2-smarthome (https://openhab.jfrog.io/openhab/eclipse-smarthome-stable): Cannot access https://openhab.jfrog.io/openhab/eclipse-smarthome-stable with type p2 using the available connector factories: BasicRepositoryConnectorFactory
```
From what I see, we do not at all require the p2 repos for the distro build, so they should be removed.

Signed-off-by: Kai Kreuzer <kai@openhab.org>