### PR TITLE
Relax Jetty's HTTP compatibility warnings

### DIFF
--- a/distributions/openhab/src/main/resources/bin/setenv
+++ b/distributions/openhab/src/main/resources/bin/setenv
@@ -87,6 +87,7 @@ export JAVA_OPTS="${JAVA_OPTS}
   -Dopenhab.logdir=${OPENHAB_LOGDIR}
   -Dfelix.cm.dir=${OPENHAB_USERDATA}/config
   -Djetty.host=${HTTP_ADDRESS}
+  -Djetty.http.compliance=RFC2616
   -Dorg.ops4j.pax.web.listening.addresses=${HTTP_ADDRESS}
   -Dorg.osgi.service.http.port=${HTTP_PORT}
   -Dorg.osgi.service.http.port.secure=${HTTPS_PORT}"

--- a/distributions/openhab/src/main/resources/bin/setenv.bat
+++ b/distributions/openhab/src/main/resources/bin/setenv.bat
@@ -108,6 +108,7 @@ set JAVA_OPTS=%JAVA_OPTS% ^
   -Dopenhab.logdir=%OPENHAB_LOGDIR% ^
   -Dfelix.cm.dir=%OPENHAB_USERDATA%\config ^
   -Djetty.host=%HTTP_ADDRESS% ^
+  -Djetty.http.compliance=RFC2616 ^
   -Dorg.ops4j.pax.web.listening.addresses=%HTTP_ADDRESS% ^
   -Dorg.osgi.service.http.port=%HTTP_PORT% ^
   -Dorg.osgi.service.http.port.secure=%HTTPS_PORT%


### PR DESCRIPTION
There are [reports](https://community.openhab.org/t/jetty-update-karaf-4-1-3-upgrade-and-full-lsp-support/36354/109) of Jetty warnings in the log like:
```
2017-12-06 12:21:33.776 [WARN ] [org.eclipse.jetty.http.HttpParser   ] - Illegal character 0x7F in state=HEADER_IN_VALUE for buffer DirectByteBuffer@7955e47b[p=188,l=2414,c=16384,r=2226]={HTTP/1.1 200 OK\r\n... 2017 04:21:33<<<\r\nEXT:\r\n\r\n<?xml v.../device></root>>>>\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00...\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00}
2017-12-06 12:21:33.780 [WARN ] [org.eclipse.jetty.http.HttpParser   ] - bad HTTP parsed: 400 Illegal character 0x7F for HttpReceiverOverHTTP@3c577535(rsp=HEADER,failure=null)[HttpParser{s=HEADER_IN_VALUE,0 of 2216}]
2017-12-06 12:21:33.971 [WARN ] [org.eclipse.jetty.http.HttpParser   ] - Illegal character 0x7F in state=HEADER_IN_VALUE for buffer DirectByteBuffer@7955e47b[p=188,l=2414,c=16384,r=2226]={HTTP/1.1 200 OK\r\n... 2017 04:21:33<<<\r\nEXT:\r\n\r\n<?xml v.../device></root>>>>\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00...\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00}
2017-12-06 12:21:33.971 [WARN ] [org.eclipse.jetty.http.HttpParser   ] - bad HTTP parsed: 400 Illegal character 0x7F for HttpReceiverOverHTTP@24b9bf7f(rsp=HEADER,failure=null)[HttpParser{s=HEADER_IN_VALUE,0 of 2216}]
2017-12-06 12:21:34.458 [WARN ] [org.eclipse.jetty.http.HttpParser   ] - Illegal character 0x7F in state=HEADER_IN_VALUE for buffer DirectByteBuffer@7955e47b[p=188,l=2414,c=16384,r=2226]={HTTP/1.1 200 OK\r\n... 2017 04:21:34<<<\r\nEXT:\r\n\r\n<?xml v.../device></root>>>>me>NewInternalPor...\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00}
2017-12-06 12:21:34.460 [WARN ] [org.eclipse.jetty.http.HttpParser   ] - bad HTTP parsed: 400 Illegal character 0x7F for HttpReceiverOverHTTP@4085cb93(rsp=HEADER,failure=null)[HttpParser{s=HEADER_IN_VALUE,0 of 2216}]
```
which seem to be caused through HTTP requests of devices that do not comply to the HTTP spec.
With this change, Jetty should silently accept such requests without warnings.

Signed-off-by: Kai Kreuzer <kai@openhab.org>