### PR TITLE
remove minimal feature definition & filter maven download warning log…

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg
@@ -56,6 +56,9 @@ log4j2.logger.jupnp.level = ERROR
 log4j2.logger.jmdns.name = javax.jmdns
 log4j2.logger.jmdns.level = ERROR
 
+log4j2.logger.paxurl.name = org.ops4j.pax.url.mvn.internal.AetherBasedResolver
+log4j2.logger.paxurl.level = ERROR
+
 #log4j2.logger.org.ops4j.pax.web.service.jetty.internal.JettyServerWrapper = ERROR
 #log4j2.logger.org.ops4j.pax.web.service.jetty.internal.JettyServerWrapper = ERROR
 

--- a/features/distro/src/main/feature/feature.xml
+++ b/features/distro/src/main/feature/feature.xml
@@ -34,16 +34,6 @@
         </config>
     </feature>
 
-    <feature name="openhab-package-minimal" description="openHAB Minimal Package" version="${project.version}">
-        <feature>openhab-runtime-base</feature>
-        <config name="org.openhab.addons" append="true">
-			package = minimal
-        </config>
-        <config name="org.eclipse.smarthome.links">
-			autoLinks = false
-        </config>
-    </feature>
-
     <feature name="openhab-package-simple" description="openHAB Simple Package" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <config name="org.openhab.addons" append="true">


### PR DESCRIPTION
… messages as they only clutter the log (and we log errors ourselves if a feature download fails)

Related to #602

Signed-off-by: Kai Kreuzer <kai@openhab.org>