### PR TITLE
filter out known exceptions from the log

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg
@@ -59,8 +59,11 @@ log4j2.logger.jmdns.level = ERROR
 log4j2.logger.paxurl.name = org.ops4j.pax.url.mvn.internal.AetherBasedResolver
 log4j2.logger.paxurl.level = ERROR
 
-#log4j2.logger.org.ops4j.pax.web.service.jetty.internal.JettyServerWrapper = ERROR
-#log4j2.logger.org.ops4j.pax.web.service.jetty.internal.JettyServerWrapper = ERROR
+log4j2.logger.paxweb.name = org.ops4j.pax.web.pax-web-runtime
+log4j2.logger.paxweb.level = OFF
+
+log4j2.logger.lsp4j.name = org.eclipse.lsp4j
+log4j2.logger.lsp4j.level = OFF
 
 # Appenders configuration
 

--- a/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg
@@ -56,12 +56,21 @@ log4j2.logger.jupnp.level = ERROR
 log4j2.logger.jmdns.name = javax.jmdns
 log4j2.logger.jmdns.level = ERROR
 
+# This suppresses all Maven download issues from the log when doing feature installations
+# as we are logging errors ourselves in a nicer way anyhow.
 log4j2.logger.paxurl.name = org.ops4j.pax.url.mvn.internal.AetherBasedResolver
 log4j2.logger.paxurl.level = ERROR
 
+# Filters known issues of pax-web (issue link to be added here).
+# Can be removed once the issues are resolved in an upcoming version.
 log4j2.logger.paxweb.name = org.ops4j.pax.web.pax-web-runtime
 log4j2.logger.paxweb.level = OFF
 
+# Filters known issues of lsp4j, see
+# https://github.com/eclipse/smarthome/issues/4639
+# https://github.com/eclipse/smarthome/issues/4629
+# https://github.com/eclipse/smarthome/issues/4643
+# Can be removed once the issues are resolved in an upcoming version.
 log4j2.logger.lsp4j.name = org.eclipse.lsp4j
 log4j2.logger.lsp4j.level = OFF
 


### PR DESCRIPTION
This addresses https://github.com/eclipse/smarthome/issues/4639, https://github.com/eclipse/smarthome/issues/4629 and https://github.com/eclipse/smarthome/issues/4643 as those exceptions merely clutter the log, while not having any noticeable impact on the functionality.

/cc: @mhilbush, you might want to test the next distro build, if it works as expected.

It also filters out pax-web errors like
```
2017-12-01 16:39:09.004 [ERROR] [org.ops4j.pax.web.pax-web-runtime   ] - FrameworkEvent ERROR - org.ops4j.pax.web.pax-web-runtime
org.osgi.framework.ServiceException: Exception in org.ops4j.pax.web.service.internal.Activator$1.ungetService()
	at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse.factoryUngetService(ServiceFactoryUse.java:270) [?:?]
	at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse.ungetService(ServiceFactoryUse.java:160) [?:?]
	at org.eclipse.osgi.internal.serviceregistry.ServiceConsumer$2.ungetService(ServiceConsumer.java:50) [?:?]
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.ungetService(ServiceRegistrationImpl.java:581) [?:?]
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.ungetService(ServiceRegistry.java:540) [?:?]
	at org.eclipse.osgi.internal.framework.BundleContextImpl.ungetService(BundleContextImpl.java:661) [?:?]
	at org.apache.felix.scr.impl.manager.DependencyManager$AbstractCustomizer.ungetService(DependencyManager.java:228) [42:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.DependencyManager$SingleDynamicCustomizer.closeRefPair(DependencyManager.java:945) [42:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.DependencyManager$SingleDynamicCustomizer.close(DependencyManager.java:937) [42:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.DependencyManager.deactivate(DependencyManager.java:1265) [42:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.deactivateDependencyManagers(AbstractComponentManager.java:1233) [42:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.doDeactivate(AbstractComponentManager.java:815) [42:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.deactivateInternal(AbstractComponentManager.java:788) [42:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.dispose(AbstractComponentManager.java:580) [42:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.ConfigurableComponentHolder.disposeComponents(ConfigurableComponentHolder.java:706) [42:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.BundleComponentActivator.dispose(BundleComponentActivator.java:523) [42:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.Activator.disposeComponents(Activator.java:439) [42:org.apache.felix.scr:2.0.12]
```
which are clearly no issue in openHAB.

Signed-off-by: Kai Kreuzer <kai@openhab.org>