### PR TITLE
Use crlf line endings for bat files

### DIFF
--- a/distributions/openhab/src/main/descriptors/archive.xml
+++ b/distributions/openhab/src/main/descriptors/archive.xml
@@ -24,8 +24,20 @@
 
         <!-- KARAF_HOME -->
         <fileSet>
+            <!-- see https://github.com/openhab/openhab-distro/issues/562 -->
             <directory>target/assembly</directory>
             <outputDirectory>runtime</outputDirectory>
+            <includes>
+                <include>bin/*.bat</include>
+            </includes>
+            <lineEnding>crlf</lineEnding>
+        </fileSet>
+        <fileSet>
+            <directory>target/assembly</directory>
+            <outputDirectory>runtime</outputDirectory>
+            <excludes>
+                <exclude>bin/*.bat</exclude>
+            </excludes>
             <includes>
                 <include>bin/**</include>
             </includes>
@@ -77,14 +89,14 @@
             <source>src/main/resources/home/start.bat</source>
             <outputDirectory></outputDirectory>
             <fileMode>0644</fileMode>
-            <lineEnding>windows</lineEnding>
+            <lineEnding>crlf</lineEnding>
             <filtered>true</filtered>
         </file>
         <file>
             <source>src/main/resources/home/start_debug.bat</source>
             <outputDirectory></outputDirectory>
             <fileMode>0644</fileMode>
-            <lineEnding>windows</lineEnding>
+            <lineEnding>crlf</lineEnding>
         </file>
     </files>
 


### PR DESCRIPTION
addresses #562

I would expect that this fixes the issue, but for some reason, trying it locally, I only see those endings on start.bat, but e.g. not on stop.bat. Maybe Jenkins or another Maven version is more successful, though and the change should do no harm.

Signed-off-by: Kai Kreuzer <kai@openhab.org>