### PR TITLE
reduced scan frequency of FileInstall and only activate it once the rest of the stack is up (level 90)

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/org.apache.felix.fileinstall-deploy.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.apache.felix.fileinstall-deploy.cfg
@@ -1,7 +1,7 @@
 felix.fileinstall.dir           = ${openhab.home}/addons
 felix.fileinstall.tmpdir        = ${karaf.data}/tmp/bundles
-felix.fileinstall.poll          = 1000
+felix.fileinstall.poll          = 10000
 felix.fileinstall.start.level   = 80
-felix.fileinstall.active.level  = 80
+felix.fileinstall.active.level  = 90
 felix.fileinstall.log.level     = 3
 felix.fileinstall.subdir.mode   = skip


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>