### PR TITLE
fix string in shell.init.script

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/shell.init.script
+++ b/distributions/openhab/src/main/resources/userdata/etc/shell.init.script
@@ -43,10 +43,6 @@ __load_class = {
 // as they do occur if the session is headless / non-interactive
 jlineReader = $.reader
 if { %(jlineReader != null) } {
-
-  # On 256 colors terminal, add a right prompt
-  max_colors = ($.jline.terminal getNumericCapability max_colors)
-
   setopt group
   setopt auto-fresh-line
   unsetopt insert-tab

--- a/distributions/openhab/src/main/resources/userdata/etc/shell.init.script
+++ b/distributions/openhab/src/main/resources/userdata/etc/shell.init.script
@@ -47,7 +47,7 @@ if { %(jlineReader != null) } {
   # On 256 colors terminal, add a right prompt
   max_colors = ($.jline.terminal getNumericCapability max_colors)
   if { %(max_colors >= 256) } {
-    __rprompt_formatter = (((__load_class java.text.SimpleDateFormat) getConstructor (__load_class java.lang.String)) newInstance \'$'\u001B\[90m'\'HH:mm:ss)
+    __rprompt_formatter = (((__load_class java.text.SimpleDateFormat) getConstructor (__load_class java.lang.String)) newInstance '$'\u001B\[90m'\'HH:mm:ss)
     __date_class = (__load_class java.util.Date)
 // Do not use right prompt by default    
 //    \#rprompt = { $__rprompt_formatter format ($__date_class newInstance) }

--- a/distributions/openhab/src/main/resources/userdata/etc/shell.init.script
+++ b/distributions/openhab/src/main/resources/userdata/etc/shell.init.script
@@ -46,12 +46,6 @@ if { %(jlineReader != null) } {
 
   # On 256 colors terminal, add a right prompt
   max_colors = ($.jline.terminal getNumericCapability max_colors)
-  if { %(max_colors >= 256) } {
-    __rprompt_formatter = (((__load_class java.text.SimpleDateFormat) getConstructor (__load_class java.lang.String)) newInstance '$'\u001B\[90m'\'HH:mm:ss)
-    __date_class = (__load_class java.util.Date)
-// Do not use right prompt by default    
-//    \#rprompt = { $__rprompt_formatter format ($__date_class newInstance) }
-  }
 
   setopt group
   setopt auto-fresh-line


### PR DESCRIPTION
I really have no idea what I'm doing and how it is intended to be like, but counting the (unescaped) quotation marks I think karaf is completely right to complain about some string indices etc... 

fixes #570
fixes openhab/openhab-docker#128
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>