### PR TITLE
Fix Windows update.ps1 backup command and add version auto increment feature

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.ps1
+++ b/distributions/openhab/src/main/resources/bin/update.ps1
@@ -94,7 +94,7 @@ Function Update-openHAB {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline=$True)]
-        [string]$OHDirectory = ".",
+        [string]$OHDirectory = (pwd).ToString().ToLower(),
         [Parameter(ValueFromPipeline=$True)]
         [string]$OHVersion,
         [Parameter(ValueFromPipeline=$True)]


### PR DESCRIPTION
- Changed backup command to use $OHDirectory to fix issue where thedefined update parameter would not be passed.
- Removed default version of 2.1.0 and added auto increment feature

Signed-off-by: Brian Leedy awsnap@gmail.com