### PR TITLE
Windows start.bat enhancements

### DIFF
--- a/distributions/openhab-addons-legacy/pom.xml
+++ b/distributions/openhab-addons-legacy/pom.xml
@@ -47,13 +47,6 @@
                     </archive>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/distributions/openhab-addons/pom.xml
+++ b/distributions/openhab-addons/pom.xml
@@ -47,13 +47,6 @@
                     </archive>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -174,13 +174,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/features/addons-esh/pom.xml
+++ b/features/addons-esh/pom.xml
@@ -31,13 +31,6 @@
                     <overwriteChangedDependencies>true</overwriteChangedDependencies>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/features/distro-kar/pom.xml
+++ b/features/distro-kar/pom.xml
@@ -48,13 +48,6 @@
                     </archive>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/features/distro-kar/src/main/feature/feature.xml
+++ b/features/distro-kar/src/main/feature/feature.xml
@@ -8,7 +8,6 @@
         <configfile finalname="${openhab.conf}/things/demo.things" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/things</configfile>
         <configfile finalname="${openhab.conf}/rules/demo.rules" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/rules</configfile>
         <configfile finalname="${openhab.conf}/scripts/demo.script" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/scripts</configfile>
-        <configfile finalname="${openhab.conf}/persistence/logging.persist" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/persistence-logging</configfile>
         <configfile finalname="${openhab.conf}/persistence/rrd4j.persist" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/persistence-rrd4j</configfile>
         <configfile finalname="${openhab.conf}/transform/en.map" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/transform-en</configfile>
         <configfile finalname="${openhab.conf}/transform/de.map" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/transform-de</configfile>

--- a/features/distro-resources/pom.xml
+++ b/features/distro-resources/pom.xml
@@ -73,13 +73,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<configuration>
-					<skip>false</skip>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/features/distro/pom.xml
+++ b/features/distro/pom.xml
@@ -62,13 +62,6 @@
                     <overwriteChangedDependencies>true</overwriteChangedDependencies>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/features/distro/src/main/feature/feature.xml
+++ b/features/distro/src/main/feature/feature.xml
@@ -8,7 +8,6 @@
         <configfile finalname="${openhab.conf}/things/demo.things" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/things</configfile>
         <configfile finalname="${openhab.conf}/rules/demo.rules" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/rules</configfile>
         <configfile finalname="${openhab.conf}/scripts/demo.script" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/scripts</configfile>
-        <configfile finalname="${openhab.conf}/persistence/logging.persist" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/persistence-logging</configfile>
         <configfile finalname="${openhab.conf}/persistence/rrd4j.persist" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/persistence-rrd4j</configfile>
         <configfile finalname="${openhab.conf}/transform/en.map" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/transform-en</configfile>
         <configfile finalname="${openhab.conf}/transform/de.map" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/transform-de</configfile>

--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,12 @@
 
     <properties>
         <build.number>- local build -</build.number>
-        <online.repo.version>2.0.0.nightly</online.repo.version>
+        <online.repo.version>2.0</online.repo.version>
 
-        <esh.version>0.9.0-SNAPSHOT</esh.version>
-        <ohc.version>2.0.0-SNAPSHOT</ohc.version>
-        <oh2.version>2.0.0-SNAPSHOT</oh2.version>
-        <oh1.version>1.9.0-SNAPSHOT</oh1.version>
+        <esh.version>0.9.0.b4</esh.version>
+        <ohc.version>2.0.0</ohc.version>
+        <oh2.version>2.0.0</oh2.version>
+        <oh1.version>1.9.0</oh1.version>
         <kat.version>1.4.1</kat.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <oh2.version>2.0.0</oh2.version>
         <oh1.version>1.9.0</oh1.version>
         <kat.version>1.4.1</kat.version>
+        <tycho.version>0.24.0</tycho.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -291,4 +292,29 @@
             </snapshots>
         </repository>
     </repositories>
+
+    <profiles>
+        <profile>
+            <id>prepare-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.tycho</groupId>
+                        <artifactId>tycho-versions-plugin</artifactId>
+                        <version>${tycho.version}</version>
+                        <executions>
+                            <execution>
+                                <id>update-version</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>set-version</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -110,15 +110,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
 
     <pluginRepositories>


### PR DESCRIPTION
I want start.bat to check the JAVA_HOME environmental variable and give an error if it's not found instead of just flashing a DOS box and going away.

I'm open to comments if it's the right place to do it or not. karaf.bat checks, but if JAVA_HOME is set incorrectly, I'm not sure it makes it that far in the batch files and it doesn't report an error.

I hope I did the PR correctly.