### PR TITLE
Add unicode file encoding jvm property

### DIFF
--- a/distributions/openhab/src/main/resources/bin/setenv
+++ b/distributions/openhab/src/main/resources/bin/setenv
@@ -96,7 +96,7 @@ export JAVA_OPTS="${JAVA_OPTS}
 # set JVM options
 #
 ARCH=`uname -m`
-EXTRA_JAVA_OPTS_COMMON="-Djava.awt.headless=true"
+EXTRA_JAVA_OPTS_COMMON="-Djava.awt.headless=true -Dfile.encoding=UTF-8"
 EXTRA_JAVA_OPTS_ARCH=""
 case "$ARCH" in
     *arm*) ;;

--- a/distributions/openhab/src/main/resources/bin/setenv.bat
+++ b/distributions/openhab/src/main/resources/bin/setenv.bat
@@ -115,7 +115,8 @@ set JAVA_OPTS=%JAVA_OPTS% ^
 
 :: set jvm options
 set EXTRA_JAVA_OPTS=-XX:+UseG1GC ^
-  -Djava.awt.headless=true
+  -Djava.awt.headless=true ^
+  -Dfile.encoding=UTF-8
 
 :: set JAVA_HOME if not set yet
 rem Setup the Java Virtual Machine


### PR DESCRIPTION
I just wan't to add a JVM property for loading config files with unicode encoding. This works well for me and some of my friends. You can see an example here: [Click](https://community.openhab.org/t/encoding-problem-solution-on-apt-repo-installation/34448)

I am not sure if it is a good idea for everyone. Maybe there are particular reasons to not set this property I am not aware off.