### PR TITLE
WIP: Update ZigBee feature to split bundles per dongle

### DIFF
--- a/features/addons/src/main/feature/feature.xml
+++ b/features/addons/src/main/feature/feature.xml
@@ -3,10 +3,13 @@
 
 	<!-- these are 2.x add-ons in separate repositories (which do not have their own Karaf feature defined), so we include them here -->
 
-    <feature name="openhab-binding-zigbee" description="ZigBee Binding" version="${project.version}">
+    <feature name="openhab-binding-zigbee-ember" description="ZigBee Binding for Ember NCP" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-serial</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.zigbee/${project.version}</bundle>
+        <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.zigbee.ember/${project.version}</bundle>
+        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee</bundle>
+        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.ember</bundle>
     </feature>
 
     <feature name="openhab-binding-zwave" description="Z-Wave Binding" version="${project.version}">


### PR DESCRIPTION
As discussed [here](https://github.com/openhab/org.openhab.binding.zigbee/issues/47#issuecomment-366528001) the new configuration for ZigBee bundles requires the features to be split.

I'm not sure if there's additional changes required - I could guess that the mvn location for the library artefacts need to be defined somewhere. 

Please let me know if there's anything I need to add or change here. Once the structure is correct I'll also need to add the other dongles - at the moment I've just included a feature for the Ember dongle.

Clearly merging of this PR needs to be coordinated with [the PR to split the bundles](https://github.com/openhab/org.openhab.binding.zigbee/pull/159).

Signed-off-by: Chris Jackson <chris@cd-jackson.com>