### PR TITLE
Set configCfgStore=false to avoid the creation of cfg files in userdata/etc

### DIFF
--- a/distributions/openhab/src/main/filtered-resources/userdata/etc/org.apache.karaf.features.cfg
+++ b/distributions/openhab/src/main/filtered-resources/userdata/etc/org.apache.karaf.features.cfg
@@ -1,0 +1,88 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+#
+# Comma separated list of features repositories to register by default
+#
+featuresRepositories = \
+    mvn:org.openhab.distro/distro/${project.version}/xml/features, \
+    mvn:org.openhab.distro/openhab-addons/${project.version}/xml/features, \
+    mvn:org.apache.karaf.features/framework//${karaf.version}/xml/features, \
+    mvn:org.openhab.distro/overrides/${project.version}/xml/features, \
+    mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features
+
+#
+# Comma separated list of features to install at startup
+#
+featuresBoot = \
+    instance, \
+    package, \
+    log, \
+    ssh, \
+    framework, \
+    system, \
+    eventadmin, \
+    feature, \
+    shell, \
+    service, \
+    jaas, \
+    http, \
+    openhab-runtime-base, \
+    jetty, \
+    deployer, \
+    diagnostic, \
+    bundle, \
+    config, \
+    kar
+
+#
+# Resource repositories (OBR) that the features resolver can use
+# to resolve requirements/capabilities
+#
+# The format of the resourceRepositories is 
+# resourceRepositories=[xml:url|json:url],...
+# for Instance:
+#
+#resourceRepositories=xml:http://host/path/to/index.xml
+# or
+#resourceRepositories=json:http://host/path/to/index.json
+#
+
+#
+# Defines if the boot features are started in asynchronous mode (in a dedicated thread)
+#
+featuresBootAsynchronous=false
+
+#
+# Service requirements enforcement
+#
+# By default, the feature resolver checks the service requirements/capabilities of
+# bundles for new features (xml schema >= 1.3.0) in order to automatically installs
+# the required bundles.
+# The following flag can have those values:
+#   - disable: service requirements are completely ignored
+#   - default: service requirements are ignored for old features
+#   - enforce: service requirements are always verified
+#
+#serviceRequirements=default
+
+#
+# Store cfg file for config element in feature
+#
+configCfgStore=false


### PR DESCRIPTION
Fixes #635

Signed-off-by: Kai Kreuzer <kai@openhab.org>