### PR TITLE
Fix VersionRangeResolutionException on initial startup

### DIFF
--- a/distributions/openhab/src/main/filtered-resources/userdata/etc/org.apache.karaf.features.cfg
+++ b/distributions/openhab/src/main/filtered-resources/userdata/etc/org.apache.karaf.features.cfg
@@ -23,7 +23,7 @@
 featuresRepositories = \
     mvn:org.openhab.distro/distro/${project.version}/xml/features, \
     mvn:org.openhab.distro/openhab-addons/${project.version}/xml/features, \
-    mvn:org.apache.karaf.features/framework//${karaf.version}/xml/features, \
+    mvn:org.apache.karaf.features/framework/${karaf.version}/xml/features, \
     mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features
 
 #


### PR DESCRIPTION
Removing a slash  fixes the VersionRangeResolutionException showing in the log files on initial startup:

```
2018-03-29 12:32:03.019 [ERROR] [ternal.service.BootFeaturesInstaller] - Error installing boot feature repository mvn:org.apache.karaf.features/framework//4.1.5/xml/features
java.io.IOException: Error resolving artifact org.apache.karaf.features:framework:4.1.5:xml:LATEST : mvn:org.apache.karaf.features/framework//4.1.5/xml/features
	at org.apache.karaf.features.internal.service.RepositoryImpl.load(RepositoryImpl.java:91) [10:org.apache.karaf.features.core:4.1.5]
	at org.apache.karaf.features.internal.service.FeaturesServiceImpl.loadRepository(FeaturesServiceImpl.java:480) [10:org.apache.karaf.features.core:4.1.5]
	at org.apache.karaf.features.internal.service.FeaturesServiceImpl.addRepository(FeaturesServiceImpl.java:496) [10:org.apache.karaf.features.core:4.1.5]
	at org.apache.karaf.features.internal.service.FeaturesServiceImpl.addRepository(FeaturesServiceImpl.java:491) [10:org.apache.karaf.features.core:4.1.5]
	at org.apache.karaf.features.internal.service.BootFeaturesInstaller.installBootFeatures(BootFeaturesInstaller.java:98) [10:org.apache.karaf.features.core:4.1.5]
	at org.apache.karaf.features.internal.service.BootFeaturesInstaller.start(BootFeaturesInstaller.java:87) [10:org.apache.karaf.features.core:4.1.5]
	at org.apache.karaf.features.internal.osgi.Activator.doStart(Activator.java:273) [10:org.apache.karaf.features.core:4.1.5]
	at org.apache.karaf.util.tracker.BaseActivator.run(BaseActivator.java:242) [10:org.apache.karaf.features.core:4.1.5]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?]
	at java.lang.Thread.run(Thread.java:748) [?:?]
Caused by: java.io.IOException: Error resolving artifact org.apache.karaf.features:framework:4.1.5:xml:LATEST
	at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:729) ~[?:?]
	at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:659) ~[?:?]
	at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:600) ~[?:?]
	at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:567) ~[?:?]
	at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:557) ~[?:?]
	at org.ops4j.pax.url.mvn.internal.Connection.getInputStream(Connection.java:123) ~[?:?]
	at java.net.URL.openStream(URL.java:1045) ~[?:?]
	at org.apache.karaf.features.internal.service.RepositoryImpl.load(RepositoryImpl.java:86) ~[?:?]
	... 12 more
Caused by: shaded.org.eclipse.aether.resolution.VersionRangeResolutionException: No highest version found for org.apache.karaf.features:framework:4.1.5:xml:[0.0,)
	at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolveLatestVersionRange(AetherBasedResolver.java:998) ~[?:?]
	at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:703) ~[?:?]
	at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:659) ~[?:?]
	at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:600) ~[?:?]
	at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:567) ~[?:?]
	at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve(AetherBasedResolver.java:557) ~[?:?]
	at org.ops4j.pax.url.mvn.internal.Connection.getInputStream(Connection.java:123) ~[?:?]
	at java.net.URL.openStream(URL.java:1045) ~[?:?]
	at org.apache.karaf.features.internal.service.RepositoryImpl.load(RepositoryImpl.java:86) ~[?:?]
	... 12 more
```