### PR TITLE
updated to dependencies version 1.0.24, which include zigbee libs

### DIFF
--- a/launch/openhab.target
+++ b/launch/openhab.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="openHAB Target Platform" sequenceNumber="180">
+<?pde version="3.8"?><target name="openHAB Target Platform" sequenceNumber="181">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.openhab.feature.p2.feature.group" version="0.0.0"/>
@@ -20,7 +20,7 @@
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.openhab.deps.runtime.feature.group" version="0.0.0"/>
 <unit id="org.openhab.deps.test.feature.group" version="0.0.0"/>
-<repository location="https://dl.bintray.com/openhab/p2/openhab-deps-repo/1.0.23"/>
+<repository location="https://dl.bintray.com/openhab/p2/openhab-deps-repo/1.0.24"/>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>


### PR DESCRIPTION
Related to https://github.com/openhab/org.openhab.binding.zigbee/pull/159

Signed-off-by: Kai Kreuzer <kai@openhab.org>