### PR TITLE
Some improvements to demo sitemap and items

### DIFF
--- a/features/distro-resources/src/main/resources/items/demo.items
+++ b/features/distro-resources/src/main/resources/items/demo.items
@@ -14,7 +14,8 @@ Group GF_Corridor   "Corridor"      <corridor>  (gGF)
 
 Group FF_Bath       "Bathroom"      <bath>      (gFF)
 Group FF_Office     "Office"        <office>    (gFF)
-Group FF_Child      "Child's Room"  <boy_1>      (gFF)
+Group FF_Son        "Oliver's Room" <boy_1>     (gFF)
+Group FF_Daughter   "Amelia's Room" <girl_1>    (gFF)
 Group FF_Bed        "Bedroom"       <bedroom>   (gFF)
 Group FF_Corridor   "Corridor"      <corridor>  (gFF)
 
@@ -37,7 +38,8 @@ Switch Light_FF_Bath_Ceiling        "Ceiling"       (FF_Bath, Lights)
 Switch Light_FF_Bath_Mirror         "Mirror"        (FF_Bath, Lights)
 Switch Light_FF_Corridor_Ceiling    "Corridor"      (FF_Corridor, Lights)
 Switch Light_FF_Office_Ceiling      "Ceiling"       (FF_Office, Lights)
-Switch Light_FF_Child_Ceiling       "Ceiling"       (FF_Child, Lights)
+Switch Light_FF_Son_Ceiling         "Ceiling"       (FF_Son, Lights)
+Switch Light_FF_Daughter_Ceiling    "Ceiling"       (FF_Daughter, Lights)
 Switch Light_FF_Bed_Ceiling         "Ceiling"       (FF_Bed, Lights)
 
 Switch Light_C_Corridor_Ceiling     "Ceiling"       (gC, Lights)
@@ -56,7 +58,8 @@ Switch Heating_GF_Kitchen           "Kitchen"       <heating>   (GF_Kitchen, Hea
 
 Switch Heating_FF_Bath              "Bath"          <heating>   (FF_Bath, Heating)
 Switch Heating_FF_Office            "Office"        <heating>   (FF_Office, Heating)
-Switch Heating_FF_Child             "Child's Room"  <heating>   (FF_Child, Heating)
+Switch Heating_FF_Son               "Oliver's Room" <heating>   (FF_Son, Heating)
+Switch Heating_FF_Daughter          "Amelia's Room" <heating>   (FF_Daughter, Heating)
 Switch Heating_FF_Bed               "Bedroom"       <heating>   (FF_Bed, Heating)
 
 /* Rollershutters */
@@ -78,7 +81,8 @@ Number Temperature_GF_Living    "Temperature [%.1f °C]" <temperature>   (Temper
 Number Temperature_GF_Kitchen   "Temperature [%.1f °C]" <temperature>   (Temperature, GF_Kitchen, Thermostat) ["CurrentTemperature"]
 Number Temperature_FF_Bath      "Temperature [%.1f °C]" <temperature>   (Temperature, FF_Bath)
 Number Temperature_FF_Office    "Temperature [%.1f °C]" <temperature>   (Temperature, FF_Office)
-Number Temperature_FF_Child     "Temperature [%.1f °C]" <temperature>   (Temperature, FF_Child)
+Number Temperature_FF_Son       "Temperature [%.1f °C]" <temperature>   (Temperature, FF_Son)
+Number Temperature_FF_Daughter  "Temperature [%.1f °C]" <temperature>   (Temperature, FF_Daughter)
 Number Temperature_FF_Bed       "Temperature [%.1f °C]" <temperature>   (Temperature, FF_Bed)
 
 /* Windows */

--- a/features/distro-resources/src/main/resources/items/demo.items
+++ b/features/distro-resources/src/main/resources/items/demo.items
@@ -82,17 +82,17 @@ Number Temperature_FF_Child     "Temperature [%.1f °C]" <temperature>   (Temper
 Number Temperature_FF_Bed       "Temperature [%.1f °C]" <temperature>   (Temperature, FF_Bed)
 
 /* Windows */
-Contact Window_GF_Frontdoor     "Frontdoor [MAP(en.map):%s]"        (GF_Corridor, Windows)
-Contact Window_GF_Kitchen       "Kitchen [MAP(en.map):%s]"          (GF_Kitchen, Windows)
-Contact Window_GF_Living        "Terrace door [MAP(en.map):%s]"     (GF_Living, Windows)
-Contact Window_GF_Toilet        "Toilet [MAP(en.map):%s]"           (GF_Toilet, Windows)
+Contact Window_GF_Frontdoor     "Frontdoor [MAP(en.map):%s]"     <frontdoor>  (GF_Corridor, Windows)
+Contact Window_GF_Kitchen       "Kitchen [MAP(en.map):%s]"                    (GF_Kitchen, Windows)
+Contact Window_GF_Living        "Terrace door [MAP(en.map):%s]"  <door>       (GF_Living, Windows)
+Contact Window_GF_Toilet        "Toilet [MAP(en.map):%s]"                     (GF_Toilet, Windows)
 
-Contact Window_FF_Bath          "Bath [MAP(en.map):%s]"             (FF_Bath, Windows)
-Contact Window_FF_Bed           "Bedroom [MAP(en.map):%s]"          (FF_Bed, Windows)
-Contact Window_FF_Office_Window "Office Window [MAP(en.map):%s]"    (FF_Office, Windows)
-Contact Window_FF_Office_Door   "Balcony Door [MAP(en.map):%s]"     (FF_Office, Windows)
+Contact Window_FF_Bath          "Bath [MAP(en.map):%s]"                       (FF_Bath, Windows)
+Contact Window_FF_Bed           "Bedroom [MAP(en.map):%s]"                    (FF_Bed, Windows)
+Contact Window_FF_Office_Window "Office Window [MAP(en.map):%s]"              (FF_Office, Windows)
+Contact Window_FF_Office_Door   "Balcony Door [MAP(en.map):%s]"  <door>       (FF_Office, Windows)
 
-Contact Garage_Door             "Garage Door [MAP(en.map):%s]"      (Garden, Windows)
+Contact Garage_Door             "Garage Door [MAP(en.map):%s]"   <garagedoor> (Garden, Windows)
 
 Group Weather_Chart
 Number Weather_Temperature      "Outside Temperature [%.1f °C]" <temperature> (Weather, Weather_Chart) { channel="yahooweather:weather:berlin:temperature" }

--- a/features/distro-resources/src/main/resources/rules/demo.rules
+++ b/features/distro-resources/src/main/resources/rules/demo.rules
@@ -2,8 +2,8 @@ import java.util.Random
 
 var Timer timer = null
 val resList = newArrayList("640/480", "320/240", "480/360")
-val urlList = newArrayList("http://www.fillmurray.com", "http://www.fillmurray.com/g",
-                 "http://www.placecage.com", "http://www.placecage.com/c", "http://www.placecage.com/g")
+val urlList = newArrayList("https://www.fillmurray.com", "https://www.fillmurray.com/g",
+                 "https://www.placecage.com", "https://www.placecage.com/c", "https://www.placecage.com/g")
 val Random random = new Random()
 
 /**

--- a/features/distro-resources/src/main/resources/sitemaps/demo.sitemap
+++ b/features/distro-resources/src/main/resources/sitemaps/demo.sitemap
@@ -139,9 +139,9 @@ sitemap demo label="Main Menu"
 			}
 			Frame label="Multimedia Widgets" {
 				Image url="https://raw.github.com/wiki/openhab/openhab/images/features.png" label="openHAB" {
-					Text label="http://www.openHAB.org" icon="icon"
+					Text label="https://www.openHAB.org" icon="icon"
 				}
-				Video url="http://www.openhab.org/assets/smarthome.mp4"
+				Video url="https://www.openhab.org/assets/smarthome.mp4"
 				Webview url="https://en.m.wikipedia.org/w/index.php?title=Main_Page" height=8
 				Image url="http://fpoimg.com/320x240?text=openHAB" item=ImageURL
 			}

--- a/features/distro-resources/src/main/resources/sitemaps/demo.sitemap
+++ b/features/distro-resources/src/main/resources/sitemaps/demo.sitemap
@@ -1,91 +1,17 @@
 sitemap demo label="Main Menu"
 {
 	Frame {
-		Text label="First Floor" icon="firstfloor" {
-			Text label="Bathroom" icon="bath" {
-				Switch item=Light_FF_Bath_Ceiling label="Ceiling"
-				Switch item=Light_FF_Bath_Mirror label="Mirror"
-				Switch item=Heating_FF_Bath label="Heating"
-				Switch item=Shutter_FF_Bath label="Roller shutter"
-				Text item=Temperature_FF_Bath label="Temperature [%.1f °C]"
-				Text item=Window_FF_Bath label="Window [MAP(en.map):%s]"
-			}
-			Text label="Office" icon="office" {
-				Switch item=Light_FF_Office_Ceiling label="Ceiling"
-				Switch item=Heating_FF_Office label="Heating"
-				Switch item=Shutter_FF_Office_Window label="Window"
-				Switch item=Shutter_FF_Office_Door label="Door"
-				Text item=Temperature_FF_Office label="Temperature [%.1f °C]"
-				Text item=Window_FF_Office_Window label="Window [MAP(en.map):%s]"
-				Text item=Window_FF_Office_Door label="Balcony Door [MAP(en.map):%s]"
-				Text item=Wifi_Level label="Wifi Level [%d/4]"
-			}
-			Text label="Child's Room" icon="boy_1" {
-				Switch item=Light_FF_Child_Ceiling label="Ceiling"
-				Switch item=Heating_FF_Child label="Heating"
-				Text item=Temperature_FF_Child label="Temperature [%.1f °C]"
-			}
-			Text label="Bedroom" icon="bedroom" {
-				Switch item=Light_FF_Bed_Ceiling label="Ceiling"
-				Switch item=Heating_FF_Bed label="Heating"
-				Switch item=Shutter_FF_Bed label="Roller shutter"
-				Text item=Temperature_FF_Bed label="Temperature [%.1f °C]"
-				Text item=Window_FF_Bed label="Window [MAP(en.map):%s]"
-			}
-			Text label="Corridor" icon="corridor" {
-				Switch item=Light_FF_Corridor_Ceiling label="Ceiling"
-			}
-		}
-		Text label="Ground Floor" icon="groundfloor" {
-			Text label="Living Room" icon="video" {
-				Slider item=Light_GF_Living_Table label="Table"
-				Switch item=Heating_GF_Living label="Heating"
-				Switch item=Shutter_GF_Living label="Roller shutter"
-				Text item=Temperature_GF_Living label="Temperature [%.1f °C]"
-				Text item=Window_GF_Living label="Terrace door [MAP(en.map):%s]"
-			}
-			Text label="Kitchen" icon="kitchen" {
-				Switch item=Light_GF_Kitchen_Ceiling label="Ceiling"
-				Switch item=Light_GF_Kitchen_Table label="Table"
-				Switch item=Heating_GF_Kitchen label="Heating"
-				Switch item=Shutter_GF_Kitchen label="Roller shutter"
-				Text item=Temperature_GF_Kitchen label="Temperature [%.1f °C]"
-				Text item=Window_GF_Kitchen label="Window [MAP(en.map):%s]"
-			}
-			Text label="Toilet" icon="bath" {
-				Switch item=Light_GF_Toilet_Ceiling label="Ceiling"
-				Switch item=Light_GF_Toilet_Mirror label="Mirror"
-				Switch item=Heating_GF_Toilet label="Heating"
-				Switch item=Shutter_GF_Toilet label="Roller shutter"
-				Text item=Temperature_GF_Toilet label="Temperature [%.1f °C]"
-				Text item=Window_GF_Toilet label="Window [MAP(en.map):%s]"
-			}
-			Text label="Corridor" icon="corridor" {
-				Switch item=Light_GF_Corridor_Ceiling label="Ceiling"
-				Switch item=Light_GF_Corridor_Wardrobe label="Wardrobe"
-				Switch item=Heating_GF_Corridor label="Heating"
-				Text item=Temperature_GF_Corridor label="Temperature [%.1f °C]"
-				Text item=Window_GF_Frontdoor label="Frontdoor [MAP(en.map):%s]"
-			}
-		}
-		Text label="Cellar" icon="cellar" {
-			Switch item=Light_C_Corridor_Ceiling label="Ceiling"
-			Switch item=Light_C_Staircase label="Staircase"
-			Switch item=Light_C_Washing_Ceiling label="Washing"
-			Switch item=Light_C_Workshop label="Workshop"
-		}
-		Text label="Garden" icon="garden" {
-			Switch item=Light_Garden_Garage label="Garage"
-			Switch item=Light_Garden_Terrace label="Terrace"
-			Text item=Garage_Door label="Garage Door [MAP(en.map):%s]"
-		}
+		Group item=gFF label="First Floor" icon="firstfloor"
+		Group item=gGF label="Ground Floor" icon="groundfloor"
+		Group item=gC label="Cellar" icon="cellar"
+		Group item=Garden icon="garden"
 	}
 	Frame label="Weather" {
-		Text item=Weather_Temperature valuecolor=[Weather_LastUpdate=="NULL"="lightgray",Weather_LastUpdate>90="lightgray",>25="orange",>15="green",>5="orange",<=5="blue"] label="Outside Temperature [%.1f °C]" {
+		Text item=Weather_Temperature valuecolor=[Weather_LastUpdate=="NULL"="lightgray",Weather_LastUpdate>90="lightgray",>25="orange",>15="green",>5="orange",<=5="blue"] {
 			Frame {
-				Text item=Weather_Temp_Max valuecolor=[>25="orange",>15="green",>5="orange",<=5="blue"] label="Todays Maximum [%.1f °C]"
-				Text item=Weather_Temp_Min valuecolor=[>25="orange",>15="green",>5="orange",<=5="blue"] label="Todays Minimum [%.1f °C]"
-				Text item=Weather_LastUpdate visibility=[Weather_LastUpdate>30] valuecolor=[Weather_LastUpdate>120="orange", Weather_LastUpdate>300="red"] label="Chart Period"
+				Text item=Weather_Temp_Max valuecolor=[>25="orange",>15="green",>5="orange",<=5="blue"]
+				Text item=Weather_Temp_Min valuecolor=[>25="orange",>15="green",>5="orange",<=5="blue"]
+				Text item=Weather_LastUpdate visibility=[Weather_LastUpdate>30] valuecolor=[Weather_LastUpdate>120="orange", Weather_LastUpdate>300="red"]
 			}
 			Frame {
 				Switch item=Weather_Chart_Period label="Chart Period" icon="chart" mappings=[0="Hour", 1="Day", 2="Week"]
@@ -95,22 +21,22 @@ sitemap demo label="Main Menu"
 			}
 		}
 		Text label="Astronomical Data" icon="sun" {
-			Text item=Sun_Elevation label="Sun Elevation"
-			Text item=Sun_Azimuth label="Sun Azimuth"
-			Text item=Sunrise_Time label="Sunrise [%1$tH:%1$tM]"
-			Text item=Sunset_Time label="Sunset [%1$tH:%1$tM]"
-			Text item=Moon_Elevation label="Moon Elevation"
-			Text item=Moon_Azimuth label="Moon Azimuth"
-			Text item=Moon_Phase label="Moon Phase"
+			Text item=Sun_Elevation
+			Text item=Sun_Azimuth
+			Text item=Sunrise_Time
+			Text item=Sunset_Time
+			Text item=Moon_Elevation
+			Text item=Moon_Azimuth
+			Text item=Moon_Phase
 		}
 	}
 	Frame label="Demo" {
-		Text item=CurrentDate label="Date [%1$tA, %1$td.%1$tm.%1$tY]"
+		Text item=CurrentDate
 		Text label="Group Demo" icon="firstfloor" {
-			Switch item=Lights mappings=[OFF="All Off"] label="All Lights [(%d)]"
-			Group item=Heating label="No. of Active Heatings [(%d)]"
-			Group item=Windows label="Open windows [(%d)]"
-			Text item=Temperature label="Avg. Room Temperature [%.1f °C]"
+			Switch item=Lights mappings=[OFF="All Off"]
+			Group item=Heating
+			Group item=Windows
+			Text item=Temperature
 		}
 		Text label="Widget Overview" icon="chart" {
 			Frame label="Binary Widgets" {
@@ -120,22 +46,22 @@ sitemap demo label="Main Menu"
 			Frame label="Discrete Widgets" {
 				Selection item=Scene_General label="Scene Selection" mappings=[0=off, 1=TV, 2=Dinner, 3=Reading]
 				Switch item=Scene_General label="Scene" mappings=[1=TV, 2=Dinner, 3=Reading]
-				Setpoint item=Temperature_Setpoint label="Temperature [%.1f °C]" minValue=16 maxValue=28 step=0.5
+				Setpoint item=Temperature_Setpoint minValue=16 maxValue=28 step=0.5
 			}
 			Frame label="Percent-based Widgets" {
-				Slider item=DimmedLight switchSupport label="Dimmer [%d %%]"
-				Colorpicker item=RGBLight icon="slider" label="RGB Light"
-				Switch item=DemoShutter label="Roller Shutter"
-				Slider item=DemoBlinds label="Blinds [%d %%]"
+				Slider item=DimmedLight switchSupport
+				Colorpicker item=RGBLight icon="slider"
+				Switch item=DemoShutter
+				Slider item=DemoBlinds
 			}
 			Frame label="Map/Location" {
-				Mapview item=DemoLocation height=10 label="Brandenburg Gate Berlin"
+				Mapview item=DemoLocation height=10
 			}
 		}
 		Text label="Multimedia" icon="video" {
 			Frame label="Radio Control" {
-				Selection item=Radio_Station label="Radio" mappings=[0=off, 1=HR3, 2=SWR3, 3=FFH]
-				Slider item=Volume icon="soundvolume" label="Volume [%.1f %%]"
+				Selection item=Radio_Station mappings=[0=off, 1=HR3, 2=SWR3, 3=FFH]
+				Slider item=Volume icon="soundvolume"
 			}
 			Frame label="Multimedia Widgets" {
 				Image url="https://raw.github.com/wiki/openhab/openhab/images/features.png" label="openHAB" {

--- a/features/distro-resources/src/main/resources/sitemaps/demo.sitemap
+++ b/features/distro-resources/src/main/resources/sitemaps/demo.sitemap
@@ -81,11 +81,11 @@ sitemap demo label="Main Menu"
 		}
 	}
 	Frame label="Weather" {
-		Text item=Weather_Temperature valuecolor=[Weather_LastUpdate=="NULL"="lightgray",Weather_LastUpdate>90="lightgray",>25="orange",>15="green",>5="orange",<=5="blue"] {
+		Text item=Weather_Temperature valuecolor=[Weather_LastUpdate=="NULL"="lightgray",Weather_LastUpdate>90="lightgray",>25="orange",>15="green",>5="orange",<=5="blue"] label="Outside Temperature [%.1f °C]" {
 			Frame {
-				Text item=Weather_Temp_Max valuecolor=[>25="orange",>15="green",>5="orange",<=5="blue"]
-				Text item=Weather_Temp_Min valuecolor=[>25="orange",>15="green",>5="orange",<=5="blue"]
-				Text item=Weather_LastUpdate visibility=[Weather_LastUpdate>30] valuecolor=[Weather_LastUpdate>120="orange", Weather_LastUpdate>300="red"]
+				Text item=Weather_Temp_Max valuecolor=[>25="orange",>15="green",>5="orange",<=5="blue"] label="Todays Maximum [%.1f °C]"
+				Text item=Weather_Temp_Min valuecolor=[>25="orange",>15="green",>5="orange",<=5="blue"] label="Todays Minimum [%.1f °C]"
+				Text item=Weather_LastUpdate visibility=[Weather_LastUpdate>30] valuecolor=[Weather_LastUpdate>120="orange", Weather_LastUpdate>300="red"] label="Chart Period"
 			}
 			Frame {
 				Switch item=Weather_Chart_Period label="Chart Period" icon="chart" mappings=[0="Hour", 1="Day", 2="Week"]
@@ -95,22 +95,22 @@ sitemap demo label="Main Menu"
 			}
 		}
 		Text label="Astronomical Data" icon="sun" {
-			Text item=Sun_Elevation
-			Text item=Sun_Azimuth
-			Text item=Sunrise_Time
-			Text item=Sunset_Time
-			Text item=Moon_Elevation
-			Text item=Moon_Azimuth
-			Text item=Moon_Phase
+			Text item=Sun_Elevation label="Sun Elevation"
+			Text item=Sun_Azimuth label="Sun Azimuth"
+			Text item=Sunrise_Time label="Sunrise [%1$tH:%1$tM]"
+			Text item=Sunset_Time label="Sunset [%1$tH:%1$tM]"
+			Text item=Moon_Elevation label="Moon Elevation"
+			Text item=Moon_Azimuth label="Moon Azimuth"
+			Text item=Moon_Phase label="Moon Phase"
 		}
 	}
 	Frame label="Demo" {
-		Text item=CurrentDate
+		Text item=CurrentDate label="Date [%1$tA, %1$td.%1$tm.%1$tY]"
 		Text label="Group Demo" icon="firstfloor" {
-			Switch item=Lights mappings=[OFF="All Off"]
-			Group item=Heating
-			Group item=Windows
-			Text item=Temperature
+			Switch item=Lights mappings=[OFF="All Off"] label="All Lights [(%d)]"
+			Group item=Heating label="No. of Active Heatings [(%d)]"
+			Group item=Windows label="Open windows [(%d)]"
+			Text item=Temperature label="Avg. Room Temperature [%.1f °C]"
 		}
 		Text label="Widget Overview" icon="chart" {
 			Frame label="Binary Widgets" {
@@ -120,22 +120,22 @@ sitemap demo label="Main Menu"
 			Frame label="Discrete Widgets" {
 				Selection item=Scene_General label="Scene Selection" mappings=[0=off, 1=TV, 2=Dinner, 3=Reading]
 				Switch item=Scene_General label="Scene" mappings=[1=TV, 2=Dinner, 3=Reading]
-				Setpoint item=Temperature_Setpoint minValue=16 maxValue=28 step=0.5
+				Setpoint item=Temperature_Setpoint label="Temperature [%.1f °C]" minValue=16 maxValue=28 step=0.5
 			}
 			Frame label="Percent-based Widgets" {
-				Slider item=DimmedLight switchSupport
-				Colorpicker item=RGBLight icon="slider"
-				Switch item=DemoShutter
-				Slider item=DemoBlinds
+				Slider item=DimmedLight switchSupport label="Dimmer [%d %%]"
+				Colorpicker item=RGBLight icon="slider" label="RGB Light"
+				Switch item=DemoShutter label="Roller Shutter"
+				Slider item=DemoBlinds label="Blinds [%d %%]"
 			}
 			Frame label="Map/Location" {
-				Mapview item=DemoLocation height=10
+				Mapview item=DemoLocation height=10 label="Brandenburg Gate Berlin"
 			}
 		}
 		Text label="Multimedia" icon="video" {
 			Frame label="Radio Control" {
-				Selection item=Radio_Station mappings=[0=off, 1=HR3, 2=SWR3, 3=FFH]
-				Slider item=Volume icon="soundvolume"
+				Selection item=Radio_Station label="Radio" mappings=[0=off, 1=HR3, 2=SWR3, 3=FFH]
+				Slider item=Volume icon="soundvolume" label="Volume [%.1f %%]"
 			}
 			Frame label="Multimedia Widgets" {
 				Image url="https://raw.github.com/wiki/openhab/openhab/images/features.png" label="openHAB" {

--- a/features/distro-resources/src/main/resources/sitemaps/demo.sitemap
+++ b/features/distro-resources/src/main/resources/sitemaps/demo.sitemap
@@ -1,10 +1,84 @@
 sitemap demo label="Main Menu"
 {
 	Frame {
-		Group item=gFF label="First Floor" icon="firstfloor"
-		Group item=gGF label="Ground Floor" icon="groundfloor"
-		Group item=gC label="Cellar" icon="cellar"
-		Group item=Garden icon="garden"
+		Text label="First Floor" icon="firstfloor" {
+			Text label="Bathroom" icon="bath" {
+				Switch item=Light_FF_Bath_Ceiling label="Ceiling"
+				Switch item=Light_FF_Bath_Mirror label="Mirror"
+				Switch item=Heating_FF_Bath label="Heating"
+				Switch item=Shutter_FF_Bath label="Roller shutter"
+				Text item=Temperature_FF_Bath label="Temperature [%.1f °C]"
+				Text item=Window_FF_Bath label="Window [MAP(en.map):%s]"
+			}
+			Text label="Office" icon="office" {
+				Switch item=Light_FF_Office_Ceiling label="Ceiling"
+				Switch item=Heating_FF_Office label="Heating"
+				Switch item=Shutter_FF_Office_Window label="Window"
+				Switch item=Shutter_FF_Office_Door label="Door"
+				Text item=Temperature_FF_Office label="Temperature [%.1f °C]"
+				Text item=Window_FF_Office_Window label="Window [MAP(en.map):%s]"
+				Text item=Window_FF_Office_Door label="Balcony Door [MAP(en.map):%s]"
+				Text item=Wifi_Level label="Wifi Level [%d/4]"
+			}
+			Text label="Child's Room" icon="boy_1" {
+				Switch item=Light_FF_Child_Ceiling label="Ceiling"
+				Switch item=Heating_FF_Child label="Heating"
+				Text item=Temperature_FF_Child label="Temperature [%.1f °C]"
+			}
+			Text label="Bedroom" icon="bedroom" {
+				Switch item=Light_FF_Bed_Ceiling label="Ceiling"
+				Switch item=Heating_FF_Bed label="Heating"
+				Switch item=Shutter_FF_Bed label="Roller shutter"
+				Text item=Temperature_FF_Bed label="Temperature [%.1f °C]"
+				Text item=Window_FF_Bed label="Window [MAP(en.map):%s]"
+			}
+			Text label="Corridor" icon="corridor" {
+				Switch item=Light_FF_Corridor_Ceiling label="Ceiling"
+			}
+		}
+		Text label="Ground Floor" icon="groundfloor" {
+			Text label="Living Room" icon="video" {
+				Slider item=Light_GF_Living_Table label="Table"
+				Switch item=Heating_GF_Living label="Heating"
+				Switch item=Shutter_GF_Living label="Roller shutter"
+				Text item=Temperature_GF_Living label="Temperature [%.1f °C]"
+				Text item=Window_GF_Living label="Terrace door [MAP(en.map):%s]"
+			}
+			Text label="Kitchen" icon="kitchen" {
+				Switch item=Light_GF_Kitchen_Ceiling label="Ceiling"
+				Switch item=Light_GF_Kitchen_Table label="Table"
+				Switch item=Heating_GF_Kitchen label="Heating"
+				Switch item=Shutter_GF_Kitchen label="Roller shutter"
+				Text item=Temperature_GF_Kitchen label="Temperature [%.1f °C]"
+				Text item=Window_GF_Kitchen label="Window [MAP(en.map):%s]"
+			}
+			Text label="Toilet" icon="bath" {
+				Switch item=Light_GF_Toilet_Ceiling label="Ceiling"
+				Switch item=Light_GF_Toilet_Mirror label="Mirror"
+				Switch item=Heating_GF_Toilet label="Heating"
+				Switch item=Shutter_GF_Toilet label="Roller shutter"
+				Text item=Temperature_GF_Toilet label="Temperature [%.1f °C]"
+				Text item=Window_GF_Toilet label="Window [MAP(en.map):%s]"
+			}
+			Text label="Corridor" icon="corridor" {
+				Switch item=Light_GF_Corridor_Ceiling label="Ceiling"
+				Switch item=Light_GF_Corridor_Wardrobe label="Wardrobe"
+				Switch item=Heating_GF_Corridor label="Heating"
+				Text item=Temperature_GF_Corridor label="Temperature [%.1f °C]"
+				Text item=Window_GF_Frontdoor label="Frontdoor [MAP(en.map):%s]"
+			}
+		}
+		Text label="Cellar" icon="cellar" {
+			Switch item=Light_C_Corridor_Ceiling label="Ceiling"
+			Switch item=Light_C_Staircase label="Staircase"
+			Switch item=Light_C_Washing_Ceiling label="Washing"
+			Switch item=Light_C_Workshop label="Workshop"
+		}
+		Text label="Garden" icon="garden" {
+			Switch item=Light_Garden_Garage label="Garage"
+			Switch item=Light_Garden_Terrace label="Terrace"
+			Text item=Garage_Door label="Garage Door [MAP(en.map):%s]"
+		}
 	}
 	Frame label="Weather" {
 		Text item=Weather_Temperature valuecolor=[Weather_LastUpdate=="NULL"="lightgray",Weather_LastUpdate>90="lightgray",>25="orange",>15="green",>5="orange",<=5="blue"] {
@@ -20,17 +94,17 @@ sitemap demo label="Main Menu"
 				Chart item=Weather_Chart period=W refresh=3600000 visibility=[Weather_Chart_Period==2]
 			}
 		}
-        Text label="Astronomical Data" icon="sun" {
-            Text item=Sun_Elevation
-            Text item=Sun_Azimuth
-            Text item=Sunrise_Time
-            Text item=Sunset_Time
-            Text item=Moon_Elevation
-            Text item=Moon_Azimuth
-            Text item=Moon_Phase
-        }
+		Text label="Astronomical Data" icon="sun" {
+			Text item=Sun_Elevation
+			Text item=Sun_Azimuth
+			Text item=Sunrise_Time
+			Text item=Sunset_Time
+			Text item=Moon_Elevation
+			Text item=Moon_Azimuth
+			Text item=Moon_Phase
+		}
 	}
-    Frame label="Demo" {
+	Frame label="Demo" {
 		Text item=CurrentDate
 		Text label="Group Demo" icon="firstfloor" {
 			Switch item=Lights mappings=[OFF="All Off"]
@@ -69,7 +143,7 @@ sitemap demo label="Main Menu"
 				}
 				Video url="http://www.openhab.org/assets/smarthome.mp4"
 				Webview url="http://heise-online.mobi/" height=8
-                Image url="http://fpoimg.com/320x240?text=openHAB" item=ImageURL
+				Image url="http://fpoimg.com/320x240?text=openHAB" item=ImageURL
 			}
 		}
 	}

--- a/features/distro-resources/src/main/resources/sitemaps/demo.sitemap
+++ b/features/distro-resources/src/main/resources/sitemaps/demo.sitemap
@@ -142,7 +142,7 @@ sitemap demo label="Main Menu"
 					Text label="http://www.openHAB.org" icon="icon"
 				}
 				Video url="http://www.openhab.org/assets/smarthome.mp4"
-				Webview url="http://heise-online.mobi/" height=8
+				Webview url="https://en.m.wikipedia.org/w/index.php?title=Main_Page" height=8
 				Image url="http://fpoimg.com/320x240?text=openHAB" item=ImageURL
 			}
 		}

--- a/features/distro-resources/src/main/resources/sitemaps/en_GB.sitemap
+++ b/features/distro-resources/src/main/resources/sitemaps/en_GB.sitemap
@@ -1,0 +1,152 @@
+sitemap en_GB label="Main Menu"
+{
+	Frame {
+		Text label="First Floor" icon="firstfloor" {
+			Text label="Bathroom" icon="bath" {
+				Switch item=Light_FF_Bath_Ceiling label="Ceiling"
+				Switch item=Light_FF_Bath_Mirror label="Mirror"
+				Switch item=Heating_FF_Bath label="Heating"
+				Switch item=Shutter_FF_Bath label="Roller shutter"
+				Text item=Temperature_FF_Bath label="Temperature [%.1f °C]"
+				Text item=Window_FF_Bath label="Window [MAP(en.map):%s]"
+			}
+			Text label="Office" icon="office" {
+				Switch item=Light_FF_Office_Ceiling label="Ceiling"
+				Switch item=Heating_FF_Office label="Heating"
+				Switch item=Shutter_FF_Office_Window label="Window"
+				Switch item=Shutter_FF_Office_Door label="Door"
+				Text item=Temperature_FF_Office label="Temperature [%.1f °C]"
+				Text item=Window_FF_Office_Window label="Window [MAP(en.map):%s]"
+				Text item=Window_FF_Office_Door label="Balcony Door [MAP(en.map):%s]"
+				Text item=Wifi_Level label="Wifi Level [%d/4]"
+			}
+			Text label="Child's Room" icon="boy_1" {
+				Switch item=Light_FF_Child_Ceiling label="Ceiling"
+				Switch item=Heating_FF_Child label="Heating"
+				Text item=Temperature_FF_Child label="Temperature [%.1f °C]"
+			}
+			Text label="Bedroom" icon="bedroom" {
+				Switch item=Light_FF_Bed_Ceiling label="Ceiling"
+				Switch item=Heating_FF_Bed label="Heating"
+				Switch item=Shutter_FF_Bed label="Roller shutter"
+				Text item=Temperature_FF_Bed label="Temperature [%.1f °C]"
+				Text item=Window_FF_Bed label="Window [MAP(en.map):%s]"
+			}
+			Text label="Corridor" icon="corridor" {
+				Switch item=Light_FF_Corridor_Ceiling label="Ceiling"
+			}
+		}
+		Text label="Ground Floor" icon="groundfloor" {
+			Text label="Living Room" icon="video" {
+				Slider item=Light_GF_Living_Table label="Table"
+				Switch item=Heating_GF_Living label="Heating"
+				Switch item=Shutter_GF_Living label="Roller shutter"
+				Text item=Temperature_GF_Living label="Temperature [%.1f °C]"
+				Text item=Window_GF_Living label="Terrace door [MAP(en.map):%s]"
+			}
+			Text label="Kitchen" icon="kitchen" {
+				Switch item=Light_GF_Kitchen_Ceiling label="Ceiling"
+				Switch item=Light_GF_Kitchen_Table label="Table"
+				Switch item=Heating_GF_Kitchen label="Heating"
+				Switch item=Shutter_GF_Kitchen label="Roller shutter"
+				Text item=Temperature_GF_Kitchen label="Temperature [%.1f °C]"
+				Text item=Window_GF_Kitchen label="Window [MAP(en.map):%s]"
+			}
+			Text label="Toilet" icon="bath" {
+				Switch item=Light_GF_Toilet_Ceiling label="Ceiling"
+				Switch item=Light_GF_Toilet_Mirror label="Mirror"
+				Switch item=Heating_GF_Toilet label="Heating"
+				Switch item=Shutter_GF_Toilet label="Roller shutter"
+				Text item=Temperature_GF_Toilet label="Temperature [%.1f °C]"
+				Text item=Window_GF_Toilet label="Window [MAP(en.map):%s]"
+			}
+			Text label="Corridor" icon="corridor" {
+				Switch item=Light_GF_Corridor_Ceiling label="Ceiling"
+				Switch item=Light_GF_Corridor_Wardrobe label="Wardrobe"
+				Switch item=Heating_GF_Corridor label="Heating"
+				Text item=Temperature_GF_Corridor label="Temperature [%.1f °C]"
+				Text item=Window_GF_Frontdoor label="Frontdoor [MAP(en.map):%s]"
+			}
+		}
+		Text label="Cellar" icon="cellar" {
+			Switch item=Light_C_Corridor_Ceiling label="Ceiling"
+			Switch item=Light_C_Staircase label="Staircase"
+			Switch item=Light_C_Washing_Ceiling label="Washing"
+			Switch item=Light_C_Workshop label="Workshop"
+		}
+		Text label="Garden" icon="garden" {
+			Switch item=Light_Garden_Garage label="Garage"
+			Switch item=Light_Garden_Terrace label="Terrace"
+			Text item=Garage_Door label="Garage Door [MAP(en.map):%s]"
+		}
+	}
+	Frame label="Weather" {
+		Text item=Weather_Temperature valuecolor=[Weather_LastUpdate=="NULL"="lightgray",Weather_LastUpdate>90="lightgray",>25="orange",>15="green",>5="orange",<=5="blue"] label="Outside Temperature [%.1f °C]" {
+			Frame {
+				Text item=Weather_Temp_Max valuecolor=[>25="orange",>15="green",>5="orange",<=5="blue"] label="Todays Maximum [%.1f °C]"
+				Text item=Weather_Temp_Min valuecolor=[>25="orange",>15="green",>5="orange",<=5="blue"] label="Todays Minimum [%.1f °C]"
+				Text item=Weather_LastUpdate visibility=[Weather_LastUpdate>30] valuecolor=[Weather_LastUpdate>120="orange", Weather_LastUpdate>300="red"] label="Chart Period"
+			}
+			Frame {
+				Switch item=Weather_Chart_Period label="Chart Period" icon="chart" mappings=[0="Hour", 1="Day", 2="Week"]
+				Chart item=Weather_Chart period=h refresh=600000 visibility=[Weather_Chart_Period==0, Weather_Chart_Period=="NULL"]
+				Chart item=Weather_Chart period=D refresh=3600000 visibility=[Weather_Chart_Period==1]
+				Chart item=Weather_Chart period=W refresh=3600000 visibility=[Weather_Chart_Period==2]
+			}
+		}
+		Text label="Astronomical Data" icon="sun" {
+			Text item=Sun_Elevation label="Sun Elevation"
+			Text item=Sun_Azimuth label="Sun Azimuth"
+			Text item=Sunrise_Time label="Sunrise [%1$tH:%1$tM]"
+			Text item=Sunset_Time label="Sunset [%1$tH:%1$tM]"
+			Text item=Moon_Elevation label="Moon Elevation"
+			Text item=Moon_Azimuth label="Moon Azimuth"
+			Text item=Moon_Phase label="Moon Phase"
+		}
+	}
+	Frame label="Demo" {
+		Text item=CurrentDate label="Date [%1$tA, %1$td.%1$tm.%1$tY]"
+		Text label="Group Demo" icon="firstfloor" {
+			Switch item=Lights mappings=[OFF="All Off"] label="All Lights [(%d)]"
+			Group item=Heating label="No. of Active Heatings [(%d)]"
+			Group item=Windows label="Open windows [(%d)]"
+			Text item=Temperature label="Avg. Room Temperature [%.1f °C]"
+		}
+		Text label="Widget Overview" icon="chart" {
+			Frame label="Binary Widgets" {
+				Switch item=DemoSwitch label="Toggle Switch"
+				Switch item=DemoSwitch label="Button Switch" mappings=[ON="On"]
+			}
+			Frame label="Discrete Widgets" {
+				Selection item=Scene_General label="Scene Selection" mappings=[0=off, 1=TV, 2=Dinner, 3=Reading]
+				Switch item=Scene_General label="Scene" mappings=[1=TV, 2=Dinner, 3=Reading]
+				Setpoint item=Temperature_Setpoint label="Temperature [%.1f °C]" minValue=16 maxValue=28 step=0.5
+			}
+			Frame label="Percent-based Widgets" {
+				Slider item=DimmedLight switchSupport label="Dimmer [%d %%]"
+				Colorpicker item=RGBLight icon="slider" label="RGB Light"
+				Switch item=DemoShutter label="Roller Shutter"
+				Slider item=DemoBlinds label="Blinds [%d %%]"
+			}
+			Frame label="Map/Location" {
+				Mapview item=DemoLocation height=10 label="Brandenburg Gate Berlin"
+			}
+		}
+		Text label="Multimedia" icon="video" {
+			Frame label="Radio Control" {
+				Selection item=Radio_Station label="Radio" mappings=[0=off, 1=HR3, 2=SWR3, 3=FFH]
+				Slider item=Volume icon="soundvolume" label="Volume [%.1f %%]"
+			}
+			Frame label="Multimedia Widgets" {
+				Image url="https://raw.github.com/wiki/openhab/openhab/images/features.png" label="openHAB" {
+					Text label="https://www.openHAB.org" icon="icon"
+				}
+				Video url="https://www.openhab.org/assets/smarthome.mp4"
+				Webview url="https://en.m.wikipedia.org/w/index.php?title=Main_Page" height=8
+				Image url="http://fpoimg.com/320x240?text=openHAB" item=ImageURL
+			}
+		}
+	}
+}
+
+// vim: syntax=Xtend

--- a/features/distro-resources/src/main/resources/sitemaps/en_GB.sitemap
+++ b/features/distro-resources/src/main/resources/sitemaps/en_GB.sitemap
@@ -20,10 +20,15 @@ sitemap en_GB label="Main Menu"
 				Text item=Window_FF_Office_Door label="Balcony Door [MAP(en.map):%s]"
 				Text item=Wifi_Level label="Wifi Level [%d/4]"
 			}
-			Text label="Child's Room" icon="boy_1" {
-				Switch item=Light_FF_Child_Ceiling label="Ceiling"
-				Switch item=Heating_FF_Child label="Heating"
-				Text item=Temperature_FF_Child label="Temperature [%.1f °C]"
+			Text label="Oliver's Room" icon="boy_1" {
+				Switch item=Light_FF_Son_Ceiling label="Ceiling"
+				Switch item=Heating_FF_Son label="Heating"
+				Text item=Temperature_FF_Son label="Temperature [%.1f °C]"
+			}
+			Text label="Amelia's Room" icon="boy_1" {
+				Switch item=Light_FF_Daughter_Ceiling label="Ceiling"
+				Switch item=Heating_FF_Daughter label="Heating"
+				Text item=Temperature_FF_Daughter label="Temperature [%.1f °C]"
 			}
 			Text label="Bedroom" icon="bedroom" {
 				Switch item=Light_FF_Bed_Ceiling label="Ceiling"
@@ -111,7 +116,8 @@ sitemap en_GB label="Main Menu"
 			Text item=Heating label="No. of Active Heatings [(%d)]" {
 				Switch item=Heating_FF_Bath label="Bath"
 				Switch item=Heating_FF_Office label="Office"
-				Switch item=Heating_FF_Child label="Child's Room"
+				Switch item=Heating_FF_Son label="Oliver's Room"
+				Switch item=Heating_FF_Daughter label="Amelia's Room"
 				Switch item=Heating_FF_Bed label="Bedroom"
 				Switch item=Heating_GF_Living label="Living Room"
 				Switch item=Heating_GF_Kitchen label="Kitchen"

--- a/features/distro-resources/src/main/resources/sitemaps/en_GB.sitemap
+++ b/features/distro-resources/src/main/resources/sitemaps/en_GB.sitemap
@@ -108,8 +108,27 @@ sitemap en_GB label="Main Menu"
 		Text item=CurrentDate label="Date [%1$tA, %1$td.%1$tm.%1$tY]"
 		Text label="Group Demo" icon="firstfloor" {
 			Switch item=Lights mappings=[OFF="All Off"] label="All Lights [(%d)]"
-			Group item=Heating label="No. of Active Heatings [(%d)]"
-			Group item=Windows label="Open windows [(%d)]"
+			Text item=Heating label="No. of Active Heatings [(%d)]" {
+				Switch item=Heating_FF_Bath label="Bath"
+				Switch item=Heating_FF_Office label="Office"
+				Switch item=Heating_FF_Child label="Child's Room"
+				Switch item=Heating_FF_Bed label="Bedroom"
+				Switch item=Heating_GF_Living label="Living Room"
+				Switch item=Heating_GF_Kitchen label="Kitchen"
+				Switch item=Heating_GF_Toilet label="Toilet"
+				Switch item=Heating_GF_Corridor label="Corridor"
+			}
+			Text item=Windows label="Open windows [(%d)]" {
+				Text item=Window_FF_Bath label="Bath [MAP(en.map):%s]"
+				Text item=Window_FF_Office_Window label="Office [MAP(en.map):%s]"
+				Text item=Window_FF_Office_Door label="Balcony Door [MAP(en.map):%s]"
+				Text item=Window_FF_Bed label="Bedroom [MAP(en.map):%s]"
+				Text item=Window_GF_Living label="Terrace Door [MAP(en.map):%s]"
+				Text item=Window_GF_Kitchen label="Kitchen [MAP(en.map):%s]"
+				Text item=Window_GF_Toilet label="Toilet [MAP(en.map):%s]"
+				Text item=Window_GF_Frontdoor label="Frontdoor [MAP(en.map):%s]"
+				Text item=Garage_Door label="Garage Door [MAP(en.map):%s]"
+			}
 			Text item=Temperature label="Avg. Room Temperature [%.1f °C]"
 		}
 		Text label="Widget Overview" icon="chart" {

--- a/features/distro-resources/src/main/resources/sitemaps/lang_en_GB.sitemap
+++ b/features/distro-resources/src/main/resources/sitemaps/lang_en_GB.sitemap
@@ -1,4 +1,9 @@
-sitemap en_GB label="Main Menu"
+/*
+ * This sitemap file has only been created to show localized sitemaps on the demo server.
+ * For a simple setup for your home, please refer to demo.sitemap.
+ */
+
+sitemap lang_en_GB label="Main Menu"
 {
 	Frame {
 		Text label="First Floor" icon="firstfloor" {


### PR DESCRIPTION
**Don't use groups in demo sitemap**

It still has the group demos as they are useless if they don't use
groups.

* Prevents people from changing the demo server.
* Change item labels to something usefull, e.g. "Bath" in subpage
    "Bath" to "Window" in subpage "Bath"
* Needed for localized sitemap


**Use wikipedia for webview**

* Better knows
* Not only in German
* No ads
* No tracker


**Use special icons for non-windows contacts** 
A door icon for a door is better suited than a window icon

**Use https where possible**


**Add label to all sitemap elements**

Needed for translation