### PR TITLE
Localize transform files via crowdin

### DIFF
--- a/features/distro-resources/pom.xml
+++ b/features/distro-resources/pom.xml
@@ -58,7 +58,6 @@
 								<artifact><file>src/main/resources/scripts/demo.script</file><type>cfg</type><classifier>scripts</classifier></artifact>
 								<artifact><file>src/main/resources/persistence/rrd4j.persist</file><type>cfg</type><classifier>persistence-rrd4j</classifier></artifact>
 								<artifact><file>src/main/resources/transform/en.map</file><type>cfg</type><classifier>transform-en</classifier></artifact>
-								<artifact><file>src/main/resources/transform/de.map</file><type>cfg</type><classifier>transform-de</classifier></artifact>
 								<artifact><file>src/main/resources/services/logging.cfg</file><type>cfg</type><classifier>services-logging</classifier></artifact>
 								<artifact><file>src/main/resources/services/basicui.cfg</file><type>cfg</type><classifier>services-basicui</classifier></artifact>
 								<artifact><file>src/main/resources/services/classicui.cfg</file><type>cfg</type><classifier>services-classicui</classifier></artifact>

--- a/features/distro-resources/src/main/resources/transform/de.map
+++ b/features/distro-resources/src/main/resources/transform/de.map
@@ -1,3 +1,0 @@
-CLOSED=zu
-OPEN=offen
-NULL=undefiniert

--- a/features/distro-resources/src/main/resources/transform/en.map
+++ b/features/distro-resources/src/main/resources/transform/en.map
@@ -1,4 +1,5 @@
-CLOSED=closed
 OPEN=open
+CLOSED=closed
+ON=on
+OFF=off
 NULL=unknown
- 

--- a/features/distro/src/main/feature/feature.xml
+++ b/features/distro/src/main/feature/feature.xml
@@ -10,7 +10,6 @@
         <configfile finalname="${openhab.conf}/scripts/demo.script" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/scripts</configfile>
         <configfile finalname="${openhab.conf}/persistence/rrd4j.persist" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/persistence-rrd4j</configfile>
         <configfile finalname="${openhab.conf}/transform/en.map" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/transform-en</configfile>
-        <configfile finalname="${openhab.conf}/transform/de.map" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/transform-de</configfile>
         <configfile finalname="${openhab.conf}/automation/jsr223/demo.js" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/automation-js</configfile>
         <configfile finalname="${openhab.conf}/services/basicui.cfg" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/services-basicui</configfile>
         <configfile finalname="${openhab.conf}/services/classicui.cfg" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/services-classicui</configfile>


### PR DESCRIPTION
The transform files can be directly used by crowdin. I removed the german translation as this should be managed via crowdin.

I added mappings for on and off as well. What else could we add?
The astro binding mappings from @ThomDietrich (https://community.openhab.org/t/astro-items-sitemap-map-binding-example/21155) might be a good idea.

Tested it here:
PR: https://github.com/mueller-ma-bot/openhab-distro/pull/1
Config (only the transform part): https://github.com/mueller-ma-bot/openhab-distro/blob/master/crowdin.yml
Crowdin: https://crowdin.com/translate/openhab-test/152/enus-de