### PR TITLE
[685] Add dependency to feature esh-config-discovery-usbserial for ZigBee binding

### DIFF
--- a/features/addons/src/main/feature/feature.xml
+++ b/features/addons/src/main/feature/feature.xml
@@ -6,6 +6,7 @@
     <feature name="openhab-binding-zigbee" description="ZigBee Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-serial</feature>
+        <feature>esh-config-discovery-usbserial</feature>
         <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee/1.0.8</bundle>
         <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.cc2531/1.0.8</bundle>
         <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.ember/1.0.8</bundle>


### PR DESCRIPTION
This resolves https://github.com/openhab/openhab-distro/issues/685.

I was not completely sure whether the dependency to the Eclipse SmartHome feature should be directly added to the ZigBee binding feature, or whether this dependency should be added to some openhab feature (like, e.g., `openhab-runtime-base` or a new `openhab-usbserial-discovery` feature) in https://github.com/openhab/openhab-core/blob/master/features/openhab-core/src/main/feature/feature.xml.

I decided to add the direct dependency to the ESH feature here; if the other way would be the preferred one, I would be happy for that feedback and open a PR in the `openhab-core` repository for that.