### PR TITLE
moving location of kar extraction to the tmp folder

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/org.apache.karaf.kar.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.apache.karaf.kar.cfg
@@ -1,0 +1,22 @@
+## Standard settings of Karaf
+
+#
+# Enable or disable the refresh of the bundles when installing
+# the features contained in a KAR file
+#
+noAutoRefreshBundles=false
+
+#
+# Enable or disable the automatic start of the bundles when installing
+# the features contained in a KAR file
+#
+noAutoStartBundles=false
+
+##########################################################################
+##
+## Custom openHAB configuration
+
+#
+# Directory where the kar are stored (when downloaded from Maven for instance)
+#
+karStorage=${karaf.data}/tmp/kar


### PR DESCRIPTION
So far, the content was extracted to `userdata/kar`, but this folder never got removed/cleaned upon a distro upgrade.

Signed-off-by: Kai Kreuzer <kai@openhab.org>