### PR TITLE
Adding upgrade notes on compatibility break for PR (3264)

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -5,6 +5,7 @@ NOTE;*.rules files are now validated upon startup. Files with errors will from n
 
 [2.3.0]
 ALERT;Oceanic Binding: The 'softener' Thing Type no longer exists and is replaced by the 'serial' and 'ethernet' Thing Types
+ALERT;YamahaReceiver Binding: Changed configuration keys. For main Thing keys changed from `HOST` to `host`, `PORT` to `port`. For zone Thing keys changed from `ZONE` to `zone`.
 
 [[PRE]]
 [2.2.0]


### PR DESCRIPTION
Updating notes to correspond with PR [3264](https://github.com/openhab/openhab2-addons/pull/3264)

Signed-off-by: Tomasz Maruszak <maruszaktomasz@gmail.com>