### PR TITLE
Avoid deletion of override.properties file

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -14,6 +14,5 @@ DEFAULT;$OPENHAB_USERDATA/etc/org.ops4j.pax.logging.cfg
 
 [[POST]]
 [2.3.0]
-DELETE;$OPENHAB_USERDATA/etc/overrides.properties
 DELETE;$OPENHAB_USERDATA/etc/org.openhab.addons.cfg
 DELETEDIR;$OPENHAB_USERDATA/kar


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>