### PR TITLE
Remove duplicated version from online-repo artifactory upload path

### DIFF
--- a/distributions/online-repo/src/main/filtered-resources/publish-artifactory.sh
+++ b/distributions/online-repo/src/main/filtered-resources/publish-artifactory.sh
@@ -5,9 +5,7 @@
 #
 ARTIFACTORY_URL=${online.repo}
 ARTIFACTORY_PACKAGE=online-repo
-PACKAGE_VERSION=${online.repo.version}
 PACKAGE_ARCHIVE=online-repo-${project.version}.zip
-PACKAGE_PATH=online-repo/$PACKAGE_VERSION
 
 if [ "x$1" != "x" ]; then
     ARTIFACTORY_USER=$1
@@ -24,7 +22,7 @@ function main() {
   cd $DIRNAME
 
   echo "Uploading archive $PACKAGE_ARCHIVE"
-  response=$(curl -s -u ${ARTIFACTORY_USER}:${ARTIFACTORY_API_KEY} -H "X-Explode-Archive-Atomic: true" -X PUT "${ARTIFACTORY_URL}/${PACKAGE_VERSION}/repo.zip" -T ${PACKAGE_ARCHIVE} )
+  response=$(curl -s -u ${ARTIFACTORY_USER}:${ARTIFACTORY_API_KEY} -H "X-Explode-Archive-Atomic: true" -X PUT "${ARTIFACTORY_URL}/repo.zip" -T ${PACKAGE_ARCHIVE} )
   echo "Upload finished: $response"
 }
 


### PR DESCRIPTION
Version is already contained by the `online.repo` property, that's why we have to remove it from the script (upload path was broken by #713, sorry!).

@kaikreuzer @martinvw: Quick merge would be appreciated, thanks!

Signed-off-by: Patrick Fink <mail@pfink.de>