### PR TITLE
Install groovy support from 4.8 snapshot branch (Photon)

### DIFF
--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2294,7 +2294,7 @@
     <requirement
         name="org.eclipse.wst.web_ui.feature.feature.group"/>
     <repository
-        url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.7/"/>
+        url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.8"/>
   </setupTask>
   <setupTask
       xsi:type="git:GitCloneTask"


### PR DESCRIPTION
This fixes dependency resolving for Eclipse Oxygen & Photon install.

Signed-off-by: Henning Treu <henning.treu@telekom.de>