### PR TITLE
Add openHAB ZigBee binding to openHAB's oomph project setup

### DIFF
--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2402,7 +2402,7 @@
           name="OH1 Add-ons">
         <predicate
             xsi:type="predicates:LocationPredicate"
-            pattern=".*/openhab/bundles/.*"/>
+            pattern=".*/openhab1-addons/bundles/.*"/>
       </workingSet>
     </setupTask>
     <setupTask

--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2430,37 +2430,92 @@
     <stream
         name="master"/>
   </project>
-  <project
-        name="4_zigbee"
-        label="openHAB ZigBee binding">
-        <setupTask
-          xsi:type="git:GitCloneTask"
-          id="git.clone.zigbeebinding"
-          remoteURI="https://github.com/openhab/org.openhab.binding.zigbee.git"
-          pushURI="https://github.com/${github.user.id}/org.openhab.binding.zigbee.git">
-        <description>openHAB ZigBee binding</description>
-      </setupTask>
-      <setupTask
-          xsi:type="setup.workingsets:WorkingSetTask">
-        <workingSet
-            name="openHAB ZigBee binding"
-            id="">
-          <predicate
-              xsi:type="predicates:LocationPredicate"
-              pattern=".*/org.openhab.binding.zigbee/.*"/>
-        </workingSet>
-      </setupTask>
-      <setupTask
-          xsi:type="projects:ProjectsImportTask">
-        <sourceLocator
-            rootFolder="${git.clone.zigbeebinding.location}"
-            locateNestedProjects="true"/>
-      </setupTask>
-      <stream
-          name="master"
-          label=""/>
+  <project name="4_zigbee"
+      label="openHAB ZigBee binding">
+    <setupTask
+        xsi:type="git:GitCloneTask"
+        id="git.clone.zigbeebinding"
+        remoteURI="https://github.com/openhab/org.openhab.binding.zigbee.git"
+        pushURI="https://github.com/${github.user.id}/org.openhab.binding.zigbee.git">
+      <description>openHAB ZigBee binding</description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup.workingsets:WorkingSetTask">
+      <workingSet
+          name="openHAB ZigBee binding"
+          id="">
+        <predicate
+            xsi:type="predicates:LocationPredicate"
+            pattern=".*/org.openhab.binding.zigbee/.*"/>
+      </workingSet>
+    </setupTask>
+    <setupTask
+        xsi:type="projects:ProjectsImportTask">
+      <sourceLocator
+          rootFolder="${git.clone.zigbeebinding.location}"
+          locateNestedProjects="true"/>
+    </setupTask>
+    <stream
+        name="master"
+        label=""/>
   </project>
-  <project name="5_esh"
+  <project name="5_zwave"
+      label="openHAB Z-Wave binding">
+    <setupTask
+        xsi:type="git:GitCloneTask"
+        id="git.clone.zwavebinding"
+        remoteURI="https://github.com/openhab/org.openhab.binding.zwave.git"
+        pushURI="https://github.com/${github.user.id}/org.openhab.binding.zwave.git">
+      <description>openHAB Z-Wave binding</description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup.workingsets:WorkingSetTask">
+      <workingSet
+          name="openHAB Z-Wave binding"
+          id="">
+        <predicate
+            xsi:type="predicates:LocationPredicate"
+            pattern=".*/org.openhab.binding.zwave"/>
+      </workingSet>
+    </setupTask>
+    <setupTask
+        xsi:type="projects:ProjectsImportTask">
+      <sourceLocator
+          rootFolder="${git.clone.zwavebinding.location}"/>
+    </setupTask>
+    <stream
+        name="master"
+        label=""/>
+  </project>
+  <project name="6_habpanel"
+      label="openHAB HABPanel">
+    <setupTask
+        xsi:type="git:GitCloneTask"
+        id="git.clone.habpanel"
+        remoteURI="https://github.com/openhab/org.openhab.ui.habpanel.git"
+        pushURI="https://github.com/${github.user.id}/org.openhab.ui.habpanel.git">
+      <description>openHAB HABPanel</description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup.workingsets:WorkingSetTask">
+      <workingSet
+          name="openHAB HABPanel"
+          id="">
+        <predicate
+            xsi:type="predicates:LocationPredicate"
+            pattern=".*/org.openhab.ui.habpanel"/>
+      </workingSet>
+    </setupTask>
+    <setupTask
+        xsi:type="projects:ProjectsImportTask">
+      <sourceLocator
+          rootFolder="${git.clone.habpanel.location}"/>
+    </setupTask>
+    <stream
+        name="master"
+        label=""/>
+  </project>
+  <project name="7_esh"
       label="Eclipse SmartHome Extensions">
     <setupTask
         xsi:type="git:GitCloneTask"
@@ -2502,7 +2557,7 @@
     <stream
         name="master"/>
   </project>
-  <project name="6_core"
+  <project name="8_core"
       label="ESH + OH2 Core Bundles">
     <setupTask
         xsi:type="git:GitCloneTask"

--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2496,7 +2496,35 @@
         name="master"
         label=""/>
   </project>
-  <project name="6_habpanel"
+  <project name="6_bacnet"
+      label="openHAB BACNet binding">
+    <setupTask
+        xsi:type="git:GitCloneTask"
+        id="git.clone.bacnetbinding"
+        remoteURI="https://github.com/openhab/org.openhab.binding.bacnet.git"
+        pushURI="https://github.com/${github.user.id}/org.openhab.binding.bacnet.git">
+      <description>openHAB BACNet binding</description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup.workingsets:WorkingSetTask">
+      <workingSet
+          name="openHAB BACNet binding"
+          id="">
+        <predicate
+            xsi:type="predicates:LocationPredicate"
+            pattern=".*/org.openhab.binding.bacnet"/>
+      </workingSet>
+    </setupTask>
+    <setupTask
+        xsi:type="projects:ProjectsImportTask">
+      <sourceLocator
+          rootFolder="${git.clone.bacnetbinding.location}"/>
+    </setupTask>
+    <stream
+        name="master"
+        label=""/>
+  </project>
+  <project name="7_habpanel"
       label="openHAB HABPanel">
     <setupTask
         xsi:type="git:GitCloneTask"
@@ -2524,7 +2552,7 @@
         name="master"
         label=""/>
   </project>
-  <project name="7_habmin"
+  <project name="8_habmin"
       label="openHAB HABmin">
     <setupTask
         xsi:type="git:GitCloneTask"
@@ -2552,7 +2580,7 @@
         name="master"
         label=""/>
   </project>
-  <project name="8_esh"
+  <project name="9_esh"
       label="Eclipse SmartHome Extensions">
     <setupTask
         xsi:type="git:GitCloneTask"
@@ -2594,7 +2622,7 @@
     <stream
         name="master"/>
   </project>
-  <project name="9_core"
+  <project name="10_core"
       label="ESH + OH2 Core Bundles">
     <setupTask
         xsi:type="git:GitCloneTask"

--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2431,18 +2431,18 @@
         name="master"/>
   </project>
   <project name="4_zigbee"
-      label="openHAB ZigBee binding">
+      label="openHAB ZigBee Binding">
     <setupTask
         xsi:type="git:GitCloneTask"
         id="git.clone.zigbeebinding"
         remoteURI="https://github.com/openhab/org.openhab.binding.zigbee.git"
         pushURI="https://github.com/${github.user.id}/org.openhab.binding.zigbee.git">
-      <description>openHAB ZigBee binding</description>
+      <description>openHAB ZigBee Binding</description>
     </setupTask>
     <setupTask
         xsi:type="setup.workingsets:WorkingSetTask">
       <workingSet
-          name="openHAB ZigBee binding"
+          name="openHAB ZigBee Binding"
           id="">
         <predicate
             xsi:type="predicates:LocationPredicate"
@@ -2460,18 +2460,18 @@
         label=""/>
   </project>
   <project name="5_zwave"
-      label="openHAB Z-Wave binding">
+      label="openHAB Z-Wave Binding">
     <setupTask
         xsi:type="git:GitCloneTask"
         id="git.clone.zwavebinding"
         remoteURI="https://github.com/openhab/org.openhab.binding.zwave.git"
         pushURI="https://github.com/${github.user.id}/org.openhab.binding.zwave.git">
-      <description>openHAB Z-Wave binding</description>
+      <description>openHAB Z-Wave Binding</description>
     </setupTask>
     <setupTask
         xsi:type="setup.workingsets:WorkingSetTask">
       <workingSet
-          name="openHAB Z-Wave binding"
+          name="openHAB Z-Wave Binding"
           id="">
         <predicate
             xsi:type="predicates:AndPredicate">
@@ -2497,18 +2497,18 @@
         label=""/>
   </project>
   <project name="6_bacnet"
-      label="openHAB BACNet binding">
+      label="openHAB BACNet Binding">
     <setupTask
         xsi:type="git:GitCloneTask"
         id="git.clone.bacnetbinding"
         remoteURI="https://github.com/openhab/org.openhab.binding.bacnet.git"
         pushURI="https://github.com/${github.user.id}/org.openhab.binding.bacnet.git">
-      <description>openHAB BACNet binding</description>
+      <description>openHAB BACNet Binding</description>
     </setupTask>
     <setupTask
         xsi:type="setup.workingsets:WorkingSetTask">
       <workingSet
-          name="openHAB BACNet binding"
+          name="openHAB BACNet Binding"
           id="">
         <predicate
             xsi:type="predicates:LocationPredicate"

--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -116,7 +116,7 @@
           xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.nullUncheckedConversion"
           value="ignore"/>
-       <setupTask
+      <setupTask
           xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.parameterAssignment"
           value="warning"/>
@@ -124,7 +124,7 @@
           xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.pessimisticNullAnalysisForFreeTypeVariables"
           value="ignore"/>
-       <setupTask
+      <setupTask
           xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment"
           value="error"/>
@@ -2430,7 +2430,37 @@
     <stream
         name="master"/>
   </project>
-  <project name="4_esh"
+  <project
+        name="4_zigbee"
+        label="openHAB ZigBee binding">
+        <setupTask
+          xsi:type="git:GitCloneTask"
+          id="git.clone.zigbeebinding"
+          remoteURI="https://github.com/openhab/org.openhab.binding.zigbee.git"
+          pushURI="https://github.com/${github.user.id}/org.openhab.binding.zigbee.git">
+        <description>openHAB ZigBee binding</description>
+      </setupTask>
+      <setupTask
+          xsi:type="setup.workingsets:WorkingSetTask">
+        <workingSet
+            name="openHAB ZigBee binding"
+            id="">
+          <predicate
+              xsi:type="predicates:LocationPredicate"
+              pattern=".*/org.openhab.binding.zigbee/.*"/>
+        </workingSet>
+      </setupTask>
+      <setupTask
+          xsi:type="projects:ProjectsImportTask">
+        <sourceLocator
+            rootFolder="${git.clone.zigbeebinding.location}"
+            locateNestedProjects="true"/>
+      </setupTask>
+      <stream
+          name="master"
+          label=""/>
+  </project>
+  <project name="5_esh"
       label="Eclipse SmartHome Extensions">
     <setupTask
         xsi:type="git:GitCloneTask"
@@ -2472,7 +2502,7 @@
     <stream
         name="master"/>
   </project>
-  <project name="5_core"
+  <project name="6_core"
       label="ESH + OH2 Core Bundles">
     <setupTask
         xsi:type="git:GitCloneTask"

--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2515,7 +2515,35 @@
         name="master"
         label=""/>
   </project>
-  <project name="7_esh"
+  <project name="7_habmin"
+      label="openHAB HABmin">
+    <setupTask
+        xsi:type="git:GitCloneTask"
+        id="git.clone.habmin"
+        remoteURI="https://github.com/openhab/org.openhab.ui.habmin.git"
+        pushURI="https://github.com/${github.user.id}/org.openhab.ui.habmin.git">
+      <description>openHAB HABmin</description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup.workingsets:WorkingSetTask">
+      <workingSet
+          name="openHAB HABmin"
+          id="">
+        <predicate
+            xsi:type="predicates:LocationPredicate"
+            pattern=".*/org.openhab.ui.habmin"/>
+      </workingSet>
+    </setupTask>
+    <setupTask
+        xsi:type="projects:ProjectsImportTask">
+      <sourceLocator
+          rootFolder="${git.clone.habmin.location}"/>
+    </setupTask>
+    <stream
+        name="master"
+        label=""/>
+  </project>
+  <project name="8_esh"
       label="Eclipse SmartHome Extensions">
     <setupTask
         xsi:type="git:GitCloneTask"
@@ -2557,7 +2585,7 @@
     <stream
         name="master"/>
   </project>
-  <project name="8_core"
+  <project name="9_core"
       label="ESH + OH2 Core Bundles">
     <setupTask
         xsi:type="git:GitCloneTask"

--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2474,8 +2474,17 @@
           name="openHAB Z-Wave binding"
           id="">
         <predicate
-            xsi:type="predicates:LocationPredicate"
-            pattern=".*/org.openhab.binding.zwave"/>
+            xsi:type="predicates:AndPredicate">
+          <operand
+              xsi:type="predicates:LocationPredicate"
+              pattern=".*/org.openhab.binding.zwave"/>
+          <operand
+              xsi:type="predicates:NotPredicate">
+            <operand
+                xsi:type="predicates:LocationPredicate"
+                pattern=".*/openhab1-addons/bundles/.*"/>
+          </operand>
+        </predicate>
       </workingSet>
     </setupTask>
     <setupTask


### PR DESCRIPTION
Resolves #732

This PR adds a project for the openHAB ZigBee binding to the project setup file `openHAB2.setup` (in the same way that it is done for Eclipse Smarthome, openhab2 addons, openhab1 addons, etc.).

The PR also contains a small fix for the dynamic working set for the openhab1 addons, which contained a wrong (probably outdated) path regex.

I tested this with an installation of the new Eclipse Photon release with openhab projects selected in the install process, and it looked good to me.