### PR TITLE
Revert "Revert "added ESH version of Homematic binding to distro""

### DIFF
--- a/features/addons-esh/src/main/feature/feature.xml
+++ b/features/addons-esh/src/main/feature/feature.xml
@@ -34,6 +34,11 @@
         <feature>esh-binding-fsinternetradio</feature>
     </feature>
 
+    <feature name="openhab-binding-homematic" description="Homematic Binding" version="${project.version}">
+        <feature>openhab-transport-upnp</feature>
+        <feature>esh-binding-homematic</feature>
+    </feature>
+
     <feature name="openhab-binding-lifx" description="LIFX Binding" version="${project.version}">
         <feature>esh-binding-lifx</feature>
     </feature>


### PR DESCRIPTION
Reverts openhab/openhab-distro#731

Time to revert the revert - I have just started a new [ESH stable build](https://ci.eclipse.org/smarthome/job/SmartHomeDistribution-Stable/280/), which should now contain the Homematic binding Karaf feature as expected.