### PR TITLE
added dependency to openhab-transport-serial for serial-button-binding

### DIFF
--- a/features/addons-esh/src/main/feature/feature.xml
+++ b/features/addons-esh/src/main/feature/feature.xml
@@ -52,6 +52,7 @@
     </feature>
 
     <feature name="openhab-binding-serialbutton" description="Serial Button Binding" version="${project.version}">
+        <feature>openhab-transport-serial</feature>
         <feature>esh-binding-serialbutton</feature>
     </feature>
 


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>