### PR TITLE
adapted JS demo rule to new syntax

### DIFF
--- a/features/distro-resources/src/main/resources/automation/jsr223/demo.js
+++ b/features/distro-resources/src/main/resources/automation/jsr223/demo.js
@@ -10,13 +10,13 @@ var sRule = new SimpleRule() {
 };
 
 sRule.setTriggers([
-        new Trigger(
-            "aTimerTrigger", 
-            "timer.GenericCronTrigger", 
+    TriggerBuilder.create()
+        .withId("aTimerTrigger")
+        .withTypeUID("timer.GenericCronTrigger")
+        .withConfiguration(
             new Configuration({
                 "cronExpression": "0 * * * * ?"
-            })
-        )
+            })).build()
     ]);
 
 automationManager.addRule(sRule);


### PR DESCRIPTION
related to https://github.com/eclipse/smarthome/pull/5953

Signed-off-by: Kai Kreuzer <kai@openhab.org>