### PR TITLE
set java.library.path in order to allow putting native libs to the installation

### DIFF
--- a/distributions/openhab/src/main/resources/bin/setenv
+++ b/distributions/openhab/src/main/resources/bin/setenv
@@ -96,6 +96,7 @@ export JAVA_OPTS="${JAVA_OPTS}
   -Dopenhab.userdata=${OPENHAB_USERDATA}
   -Dopenhab.logdir=${OPENHAB_LOGDIR}
   -Dfelix.cm.dir=${OPENHAB_USERDATA}/config
+  -Djava.library.path=${OPENHAB_USERDATA}/tmp/lib
   -Djetty.host=${HTTP_ADDRESS}
   -Djetty.http.compliance=RFC2616
   -Dorg.ops4j.pax.web.listening.addresses=${HTTP_ADDRESS}

--- a/distributions/openhab/src/main/resources/bin/setenv.bat
+++ b/distributions/openhab/src/main/resources/bin/setenv.bat
@@ -111,6 +111,7 @@ set JAVA_OPTS=%JAVA_OPTS% ^
   -Dopenhab.userdata=%OPENHAB_USERDATA% ^
   -Dopenhab.logdir=%OPENHAB_LOGDIR% ^
   -Dfelix.cm.dir=%OPENHAB_USERDATA%\config ^
+  -Djava.library.path=%OPENHAB_USERDATA%\tmp\lib ^
   -Djetty.host=%HTTP_ADDRESS% ^
   -Djetty.http.compliance=RFC2616 ^
   -Dorg.ops4j.pax.web.listening.addresses=%HTTP_ADDRESS% ^


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>