### PR TITLE
Correct macOS Text-to-Speech feature description casing

### DIFF
--- a/features/addons-esh/src/main/feature/feature.xml
+++ b/features/addons-esh/src/main/feature/feature.xml
@@ -115,7 +115,7 @@
 
     <!-- voice -->
 
-    <feature name="openhab-voice-mactts" description="MacOS Text-to-Speech" version="${project.version}">
+    <feature name="openhab-voice-mactts" description="macOS Text-to-Speech" version="${project.version}">
         <feature>esh-voice-mactts</feature>
     </feature>
 


### PR DESCRIPTION
Related to https://github.com/eclipse/smarthome/pull/6056. The voice addons list in Paper UI will ignore  the character casing while sorting.