### PR TITLE
Make backup without tmp and cache

### DIFF
--- a/distributions/openhab/src/main/resources/bin/backup
+++ b/distributions/openhab/src/main/resources/bin/backup
@@ -16,7 +16,7 @@ setup(){
     echo ""
     echo "  e.g. ./backup                     << Makes a file with a timed filename"
     echo "       ./backup myBackup.zip        << Makes a file called myBackup.zip"
-    echo "  e.g. ./backup --full              << Makes a full backup file with a timed filename"
+    echo "       ./backup --full              << Makes a full backup file with a timed filename"
     echo "       ./backup --full myBackup.zip << Makes a full backup file called myBackup.zip"
     echo ""
     echo "Use this script to backup your openHAB configuration, you can use the 'restore' script"
@@ -68,7 +68,7 @@ setup(){
 
   timestamp=$(date +"%y_%m_%d-%H_%M_%S")
   ## Set the filename
-  if [ -z "$1" ] || [ "$1" = "--full" ]; then
+  if [ -z "$1" ]; then
     echo "Using '$OPENHAB_BACKUPS' as backup folder..."
     OutputFile="$OPENHAB_BACKUPS/openhab2-backup-$timestamp.zip"
   else

--- a/distributions/openhab/src/main/resources/bin/backup
+++ b/distributions/openhab/src/main/resources/bin/backup
@@ -12,13 +12,17 @@ getFullPath() {
 
 setup(){
   if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
-    echo "Usage: backup [filename]"
+    echo "Usage: backup [--full] [filename]"
     echo ""
-    echo "  e.g. ./backup                 << Makes a file with a timed filename"
-    echo "       ./backup myBackup.zip    << Makes a file called myBackup.zip"
+    echo "  e.g. ./backup                     << Makes a file with a timed filename"
+    echo "       ./backup myBackup.zip        << Makes a file called myBackup.zip"
+    echo "  e.g. ./backup --full              << Makes a full backup file with a timed filename"
+    echo "       ./backup --full myBackup.zip << Makes a full backup file called myBackup.zip"
     echo ""
     echo "Use this script to backup your openHAB configuration, you can use the 'restore' script"
     echo "from any machine to transfer your configuration across to another instance."
+    echo ""
+    echo "A full backup includes the tmp and cache directories that are normally excluded."
     echo ""
     echo "Set $OPENHAB_BACKUPS to change the default backup directory."
     exit 0
@@ -56,9 +60,10 @@ setup(){
   fileList="$OPENHAB_RUNTIME/bin/userdata_sysfiles.lst"
 
   ## Parse arguments
-  if [ "$1" = "--full" ] || [ "$2" = "--full" ]; then
+  if [ "$1" = "--full" ]; then
     echo "including cache"
     INCLUDE_CACHE="true"
+    shift
   fi
 
   timestamp=$(date +"%y_%m_%d-%H_%M_%S")


### PR DESCRIPTION
Changes the backup script so that it doesn't include tmp and cache directories. Add optional --full argument for those who want to include it.

This makes the default behaviour go back to how it worked in 2.2. For further details see https://community.openhab.org/t/openhab-cli-backup-from-700kb-to-85mb/48266 and https://github.com/openhab/openhab-distro/issues/755