### PR TITLE
Fix wrong variable name: `OPENHAB_BACKUP`

### DIFF
--- a/distributions/openhab/src/main/resources/bin/oh2_dir_layout
+++ b/distributions/openhab/src/main/resources/bin/oh2_dir_layout
@@ -21,7 +21,7 @@ if [ -z ${OPENHAB_LOGDIR} ]; then
     export OPENHAB_LOGDIR="${OPENHAB_USERDATA}/logs"
 fi
 
-if [ -z ${OPENHAB_BACKUP} ]; then
+if [ -z ${OPENHAB_BACKUPS} ]; then
     export OPENHAB_BACKUPS="${OPENHAB_HOME}/backups"
 fi
 


### PR DESCRIPTION
Signed-off-by: Markus Reiter <me@reitermark.us>