### PR TITLE
sets the backward compatibility option for the item auto updates

### DIFF
--- a/distributions/openhab/src/main/resources/runtime/services.cfg
+++ b/distributions/openhab/src/main/resources/runtime/services.cfg
@@ -12,3 +12,5 @@ org.eclipse.smarthome.folder:things=things
 org.eclipse.smarthome.threadpool:thingHandler=5
 org.eclipse.smarthome.threadpool:discovery=5
 org.eclipse.smarthome.threadpool:safeCall=10
+
+org.eclipse.smarthome.autoupdate:sendOptimisticUpdates=true

--- a/launch/home/etc/services.cfg
+++ b/launch/home/etc/services.cfg
@@ -36,3 +36,4 @@ org.eclipse.smarthome.threadpool:discovery=3
 # Non-scheduled thread pools can also provide a max size
 org.eclipse.smarthome.threadpool:safeCall=3,10
 
+org.eclipse.smarthome.autoupdate:sendOptimisticUpdates=true


### PR DESCRIPTION
This is related to https://github.com/eclipse/smarthome/pull/5011

The change makes sure to change the behavior of the auto-updates as little as possible, so that existing setups are not broken by it:

_"The previous behavior of always sending item updates can still be configured for backward compatibility"_

Signed-off-by: Kai Kreuzer <kai@openhab.org>