### PR TITLE
Upgrade to Karaf 4.2.1

### DIFF
--- a/distributions/openhab/src/main/filtered-resources/userdata/etc/org.ops4j.pax.url.mvn.cfg
+++ b/distributions/openhab/src/main/filtered-resources/userdata/etc/org.ops4j.pax.url.mvn.cfg
@@ -15,6 +15,9 @@
 #   * 3. if not found looks for ${maven.home}/conf/settings.xml
 #   * 4. if not found looks for ${M2_HOME}/conf/settings.xml
 #
+# Properties prefixed with "org.ops4j.pax.url.mvn." have
+# higher priority except <proxies> element. HTTP proxies should be configured in
+# settings file
 #org.ops4j.pax.url.mvn.settings=
 
 #
@@ -28,17 +31,21 @@ org.ops4j.pax.url.mvn.localRepository=${openhab.userdata}/tmp/mvn
 
 #
 # Default this to false. It's just weird to use undocumented repos
+# "false" means that http://repo1.maven.org/maven2@id=central won't be
+# implicitly used as remote repository
 #
 org.ops4j.pax.url.mvn.useFallbackRepositories=false
 
 #
-# Uncomment if you don't wanna use the proxy settings
-# from the Maven conf/settings.xml file
-#
-# org.ops4j.pax.url.mvn.proxySupport=false
-
-#
 # Comma separated list of repositories scanned when resolving an artifact.
+# list of repositories searched in the first place, should contain
+# ${runtime.home}/${karaf.default.repository}.
+# if "org.ops4j.pax.url.mvn.localRepository" is defined and it's not
+# ~/.m2/repository, it's recommended (at least for dev purposes) to add
+# ~/.m2/repository to defaultRepositories
+# each of these repositories is checked by aether as "local repository". if
+# artifact isn't found, "repositories" are searched next
+#
 # Those repositories will be checked before iterating through the
 #    below list of repositories and even before the local repository
 # A repository url can be appended with zero or more of the following flags:
@@ -48,31 +55,36 @@ org.ops4j.pax.url.mvn.useFallbackRepositories=false
 # The following property value will add the system folder as a repo.
 #
 org.ops4j.pax.url.mvn.defaultRepositories=\
-    file:${karaf.home}/${karaf.default.repository}@id=system.repository@snapshots, \
-    file:${karaf.data}/tmp/kar@id=kar.repository@multi@snapshots, \
-    file:${karaf.base}/${karaf.default.repository}@id=child.system.repository@snapshots
+    ${karaf.home.uri}${karaf.default.repository}@id=system.repository@snapshots, \
+    ${karaf.data.uri}tmp/kar@id=kar.repository@multi@snapshots, \
+    ${karaf.base.uri}${karaf.default.repository}@id=child.system.repository@snapshots
 
-# Use the default local repo (e.g.~/.m2/repository) as a "remote" repo
-#org.ops4j.pax.url.mvn.defaultLocalRepoAsRemote=false
+#
+# if "defaultLocalRepoAsRemote" is set to *any* value, localRepository will be
+# added to the list of remote repositories being searched for artifacts
+#
+#org.ops4j.pax.url.mvn.defaultLocalRepoAsRemote = true
 
 #
 # Comma separated list of repositories scanned when resolving an artifact.
-# 
-# Default repos:
+# list of repositories searched after resolution fails for "defaultRepositories"
+# These are true remote repositories accessed using maven/aether/wagon
+# mechanisms. If any repository contains required artifact, it is then written
+# to "localRepository"
 #
-# http://repo1.maven.org/maven2@id=central, \
-# http://repository.springsource.com/maven/bundles/release@id=spring.ebr.release, \
-# http://repository.springsource.com/maven/bundles/external@id=spring.ebr.external, \
-# http://zodiac.springsource.com/maven/bundles/release@id=gemini, \
-# http://repository.apache.org/content/groups/snapshots-group@id=apache@snapshots@noreleases, \
-# https://oss.sonatype.org/content/repositories/snapshots@id=sonatype.snapshots.deploy@snapshots@noreleases, \
-# https://oss.sonatype.org/content/repositories/ops4j-snapshots@id=ops4j.sonatype.snapshots.deploy@snapshots@noreleases, \
-# http://repository.springsource.com/maven/bundles/external@id=spring-ebr-repository@snapshots@noreleases, \
-#
+# if this list is _prepended_ with '+' sign, all repositories from active
+# profiles defined in effective settings.xml file will be _appended_ to this
+# list
+# The default list includes the following repositories:
+#    http://repo1.maven.org/maven2@id=central
+#    http://repository.apache.org/content/groups/snapshots-group@id=apache@snapshots@noreleases
+#    https://oss.sonatype.org/content/repositories/snapshots@id=sonatype.snapshots.deploy@snapshots@noreleases
+#    https://oss.sonatype.org/content/repositories/ops4j-snapshots@id=ops4j.sonatype.snapshots.deploy@snapshots@noreleases
 # A repository url can be appended with zero or more of the following flags:
 #    @snapshots  : the repository contains snapshots
 #    @noreleases : the repository does not contain any released artifacts
-#    @id=repository.id : the id for the repository, just like in the settings.xml this is optional but recommended
+#    @id=repository.id : the id for the repository, just like in the
+#        settings.xml this is optional but recommended
 #
 # This contains the openhab, smart home and default repositories.
 #

--- a/distributions/openhab/src/main/resources/bin/karaf
+++ b/distributions/openhab/src/main/resources/bin/karaf
@@ -17,15 +17,25 @@
 #
 
 realpath() {
+  # Use in priority xpg4 awk or nawk on SunOS as standard awk is outdated
+  AWK=awk
+  if ${solaris}; then
+      if [ -x /usr/xpg4/bin/awk ]; then
+          AWK=/usr/xpg4/bin/awk
+      elif [ -x /usr/bin/nawk ]; then
+          AWK=/usr/bin/nawk
+      fi
+  fi
+
   READLINK_EXISTS=$(command -v readlink &> /dev/null)
-  if [ -z $READLINK_EXISTS ]; then
+  if [ -z "$READLINK_EXISTS" ]; then
     OURPWD=${PWD}
     cd "$(dirname "${1}")" || exit 2
-    LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+    LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     while [ "${LINK}" ]; do
         echo "link: ${LINK}" >&2
         cd "$(dirname "${LINK}")" || exit 2
-        LINK=$(ls -l "$(basename "${1}")" | awk -F"-> " '{print $2}')
+        LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
     done
     REALPATH="${PWD}/$(basename "${1}")"
     cd "${OURPWD}" || exit 2
@@ -48,6 +58,7 @@ realpath() {
 REALNAME=$(realpath "$0")
 DIRNAME=$(dirname "${REALNAME}")
 PROGNAME=$(basename "${REALNAME}")
+LOCAL_CLASSPATH=$CLASSPATH
 
 #
 # Load common functions
@@ -89,9 +100,14 @@ checkRootInstance() {
       ROOT_INSTANCE_PID=$(sed -n -e '/item.0.pid/ s/.*\= *//p' "${KARAF_DATA}/tmp/instances/instance.properties")
       ROOT_INSTANCE_NAME=$(sed -n -e '/item.0.name/ s/.*\= *//p' "${KARAF_DATA}/tmp/instances/instance.properties")
       if [ "${ROOT_INSTANCE_PID}" -ne "0" ]; then
-          if ps p "${ROOT_INSTANCE_PID}" > /dev/null
+          if ps -p "${ROOT_INSTANCE_PID}" > /dev/null
           then
-              ROOT_INSTANCE_RUNNING=true
+              MAIN=org.apache.karaf.main.Main
+              PID_COMMAND=$("${PS_PREFIX}"ps -p "${ROOT_INSTANCE_PID}" -o args | sed 1d)
+
+              if [ "${PID_COMMAND#*$MAIN}" != "$PID_COMMAND" ]; then
+                ROOT_INSTANCE_RUNNING=true
+              fi
           fi
       fi
    fi
@@ -166,6 +182,7 @@ run() {
     fi
 
     debug=false
+    debugs=false
     nodebug=false
     while [ "${1}" != "" ]; do
         case "${1}" in
@@ -175,6 +192,11 @@ run() {
                 ;;
             'debug')
                 debug=true
+                shift
+                ;;
+            'debugs')
+                debug=true
+                debugs=true
                 shift
                 ;;
             'status')
@@ -228,7 +250,11 @@ run() {
     fi
     if ${debug}; then
         if [ "x${JAVA_DEBUG_OPTS}" = "x" ]; then
-            JAVA_DEBUG_OPTS="${DEFAULT_JAVA_DEBUG_OPTS}"
+            if ${debugs}; then
+                JAVA_DEBUG_OPTS="${DEFAULT_JAVA_DEBUGS_OPTS}"
+            else
+                JAVA_DEBUG_OPTS="${DEFAULT_JAVA_DEBUG_OPTS}"
+            fi
         fi
         JAVA_OPTS="${JAVA_DEBUG_OPTS} ${JAVA_OPTS}"
     fi
@@ -240,6 +266,10 @@ run() {
             echo "Updating libs..."
             rm -rf "${KARAF_HOME:?}/lib"
             mv -f "${KARAF_HOME:?}/lib.next" "${KARAF_HOME}/lib"
+
+            echo "Updating classpath..."
+            CLASSPATH=$LOCAL_CLASSPATH
+            setupClassPath
         fi
 
         # Ensure the log directory exists
@@ -252,19 +282,22 @@ run() {
         fi
 
         if [ "${ROOT_INSTANCE_RUNNING}" = "false" ] || [ "${CHECK_ROOT_INSTANCE_RUNNING}" = "false" ] ; then
-            if [ "${VERSION}" -gt "80" ]; then
+            if [ "${VERSION}" -gt "8" ]; then
                 ${KARAF_EXEC} "${JAVA}" ${JAVA_OPTS} \
+                    --add-reads=java.xml=java.logging \
+                    --patch-module java.base=lib/endorsed/org.apache.karaf.specs.locator-4.2.1.jar \
+                    --patch-module java.xml=lib/endorsed/org.apache.karaf.specs.java.xml-4.2.1.jar \
                     --add-opens java.base/java.security=ALL-UNNAMED \
                     --add-opens java.base/java.net=ALL-UNNAMED \
                     --add-opens java.base/java.lang=ALL-UNNAMED \
                     --add-opens java.base/java.util=ALL-UNNAMED \
+                    --add-opens java.naming/javax.naming.spi=ALL-UNNAMED \
+                    --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED \
                     --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED \
                     --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED \
                     --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED \
-                    --add-exports=java.xml.bind/com.sun.xml.internal.bind.v2.runtime=ALL-UNNAMED \
                     --add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED \
                     --add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED \
-                    --add-modules java.xml.ws.annotation,java.corba,java.transaction,java.xml.bind,java.xml.ws \
                     -Dkaraf.instances="${KARAF_DATA}/tmp/instances" \
                     -Dkaraf.home="${KARAF_HOME}" \
                     -Dkaraf.base="${KARAF_BASE}" \
@@ -299,7 +332,7 @@ run() {
                     ${MAIN} "$@"
             fi
         else
-            die "There is a Root instance already running with name ${ROOT_INSTANCE_NAME} and pid ${ROOT_INSTANCE_PID}"
+            die "There is a Root instance already running with name ${ROOT_INSTANCE_NAME} and pid ${ROOT_INSTANCE_PID}. If you know what you are doing and want to force the run anyway, export CHECK_ROOT_INSTANCE_RUNNING=false and re run the command."
         fi
 
         KARAF_RC=$?

--- a/distributions/openhab/src/main/resources/userdata/etc/org.apache.karaf.shell.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.apache.karaf.shell.cfg
@@ -1,3 +1,4 @@
+
 ################################################################################
 #
 #    Licensed to the Apache Software Foundation (ASF) under one or more
@@ -39,6 +40,12 @@ sshIdleTimeout = 1800000
 sshRealm = karaf
 
 #
+# Role name used for SSH access authorization
+# If not set, this defaults to the ${karaf.admin.role} configured in etc/system.properties
+#
+# sshRole = admin
+
+#
 # Defines if the SFTP system is enabled or not in the SSH server
 #
 sftpEnabled=true
@@ -56,16 +63,10 @@ hostKey = ${karaf.etc}/host.key
 hostKeyFormat = simple
 
 #
-# Role name used for SSH access authorization
-# If not set, this defaults to the ${karaf.admin.role} configured in etc/system.properties
-#
-# sshRole = admin
-
-#
 # Self defined key size in 1024, 2048, 3072, or 4096
-# If not set, this defaults to 4096.
+# If not set, this defaults to 2048.
 #
-# keySize = 4096
+# keySize = 2048
 
 #
 # Specify host key algorithm, defaults to RSA
@@ -80,7 +81,7 @@ hostKeyFormat = simple
 # 3: DEBUG
 # 4: TRACE
 #
-#logLevel=1
+#logLevel = 1
 
 #
 # Specify an additional welcome banner to be displayed when a user logs into the server.
@@ -98,6 +99,7 @@ hostKeyFormat = simple
 # This property define the default value when you use the Karaf shell console.
 # You can change the completion mode directly in the shell console, using shell:completion command.
 #
+completionMode = GLOBAL
 
 #
 # Override allowed SSH cipher algorithms.
@@ -123,4 +125,4 @@ hostKeyFormat = simple
 #
 # moduli-url = external moduli-url users wanna use
 
-completionMode = GLOBAL
+

--- a/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg
@@ -80,6 +80,11 @@ log4j2.logger.lsp4j.level = OFF
 log4j2.logger.karservice.name = org.apache.karaf.kar.internal.KarServiceImpl
 log4j2.logger.karservice.level = ERROR
 
+# Filters warnings about small thread pools.
+# The thread pool is kept small intentionally for supporting resource constrained hardware.
+log4j2.logger.threadpoolbudget.name = org.eclipse.jetty.util.thread.ThreadPoolBudget
+log4j2.logger.threadpoolbudget.level = ERROR
+
 
 # Appenders configuration
 

--- a/distributions/openhab/src/main/resources/userdata/etc/overrides.properties
+++ b/distributions/openhab/src/main/resources/userdata/etc/overrides.properties
@@ -1,4 +1,0 @@
-mvn:org.eclipse.jetty/jetty-io/9.3.21.v20170918
-mvn:org.eclipse.jetty/jetty-util/9.3.21.v20170918
-mvn:org.eclipse.jetty.websocket/websocket-common/9.3.21.v20170918
-mvn:org.eclipse.jetty.websocket/websocket-api/9.3.21.v20170918

--- a/distributions/openhab/src/main/resources/userdata/etc/scripts/shell.completion.script
+++ b/distributions/openhab/src/main/resources/userdata/etc/scripts/shell.completion.script
@@ -93,7 +93,7 @@ if { %(jlineReader != null) } {
 
   complete -c shell:cd -e
   complete -c shell:cd -d "Change current directory"
-  complete -c shell:cd -a '__directories'
+  complete -c shell:cd -a 'wi = ($.commandLine wordIndex); if { %(wi==1) } { __directories } { [ ] }'
 
   complete -c shell:sleep -e
   complete -c shell:sleep -d "Pause execution for the specified amount of time"
@@ -238,5 +238,34 @@ if { %(jlineReader != null) } {
   complete -c shell:wc -s m -l chars --description "Print character count"
   complete -c shell:wc -s w -l words --description "Print word count"
   complete -c shell:wc -a '__files'
+
+  __get_scr_components = {
+	list = [ ]
+    scrref = ($.context getServiceReference org.osgi.service.component.runtime.ServiceComponentRuntime)
+    scr = ($.context getService $scrref)
+	each ($scr getComponentDescriptionDTOs ($.context bundles)) {
+		$list add ((($it getClass) getField "name") get $it)
+	}
+	$.context ungetService $scrref
+	$list
+  }
+
+  complete -c scr:config -e
+  complete -c scr:config -d "Show the current SCR configuration"
+
+  complete -c scr:disable -e
+  complete -c scr:disable -d "Disable an enabled component"
+  complete -c scr:disable -a '__get_scr_components'
+
+  complete -c scr:enable -e
+  complete -c scr:enable -d "Enable an disabled component"
+  complete -c scr:enable -a '__get_scr_components'
+
+  complete -c scr:info -e
+  complete -c scr:info -d "Dump information of a component or component configuration"
+  complete -c scr:info -a '__get_scr_components'
+
+  complete -c scr:list -e
+  complete -c scr:list -d "List component configurations of a specific bundle"
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -57,13 +57,13 @@
         <jackson.version>1.9.13</jackson.version>
         <jna.version>4.5.2</jna.version>
 
-        <karaf.version>4.1.5</karaf.version>
-        <jetty.version>9.3.21</jetty.version>
+        <karaf.version>4.2.1</karaf.version>
+        <jetty.version>9.4.11.v20180605</jetty.version>
 
         <!-- provided by Karaf -->
         <dep.slf4j.api.groupId>org.slf4j</dep.slf4j.api.groupId>
         <dep.slf4j.api.artifactId>slf4j-api</dep.slf4j.api.artifactId>
-        <dep.slf4j.api.version>1.7.7</dep.slf4j.api.version>
+        <dep.slf4j.api.version>1.7.12</dep.slf4j.api.version>
 
         <dep.org.osgi.compendium.split.groupId>tmp.need.a.home</dep.org.osgi.compendium.split.groupId>
         <dep.org.osgi.compendium.split.component.artifact>org.osgi.compendium.split.service.component</dep.org.osgi.compendium.split.component.artifact>


### PR DESCRIPTION
Upgrades Karaf to 4.2.1. So far I haven't run into anything major while upgrading. 

There seems to be a new Jetty warning that may need to be addressed:

```
01:18:23.511 [WARN ] [se.jetty.util.thread.ThreadPoolBudget] - Low configured threads: (max=8 - required=1)=7 < warnAt=8 for QueuedThreadPool[ServletModel-37]@4b1f06{STARTING,8<=0<=8,i=0,q=0}[ReservedThreadExecutor@3bc120c4{s=0/1,p=0}]
```

Besides that it seems to work just as well as the current snapshot build. :smile:
Though it could use some additional testing of course. 

I've compiled some [test artifacts](https://github.com/wborn/openhab-distro/releases/tag/2.4.0-k421.20180912) for anyone who wants to help testing. It should also work with the online repository.

This Karaf version also supports Java 9 and 10. So I tested Java 10 on Ubuntu 18.04. The runtime starts and all UIs work properly. Though some errors/stacktraces show due to issues in some dependencies:

* XStream: https://github.com/x-stream/xstream/issues/101
* RRD4J: https://github.com/rrd4j/rrd4j/issues/72

The next step is to have another look at the current state of configuring logging using XML instead of properties files (https://github.com/openhab/openhab-distro/issues/516).