### PR TITLE
Add feature for ESH OneWire Binding

### DIFF
--- a/features/addons-esh/src/main/feature/feature.xml
+++ b/features/addons-esh/src/main/feature/feature.xml
@@ -51,6 +51,10 @@
         <feature>esh-binding-ntp</feature>
     </feature>
 
+    <feature name="openhab-binding-onewire" description="OneWire Binding" version="${project.version}">
+        <feature>esh-binding-onewire</feature>
+    </feature>
+
     <feature name="openhab-binding-serialbutton" description="Serial Button Binding" version="${project.version}">
         <feature>openhab-transport-serial</feature>
         <feature>esh-binding-serialbutton</feature>


### PR DESCRIPTION
Adds a feature for the ESH OneWire binding so it can be installed as an openHAB addons.

See also: https://github.com/openhab/openhab2-addons/issues/3943#issuecomment-421725153