### PR TITLE
invalid configuration for pool 'safeCall'

### DIFF
--- a/launch/home/etc/services.cfg
+++ b/launch/home/etc/services.cfg
@@ -34,6 +34,6 @@ org.eclipse.smarthome.threadpool:thingHandler=3
 org.eclipse.smarthome.threadpool:discovery=3
 
 # Non-scheduled thread pools can also provide a max size
-org.eclipse.smarthome.threadpool:safeCall=3,10
+org.eclipse.smarthome.threadpool:safeCall=3
 
 org.eclipse.smarthome.autoupdate:sendOptimisticUpdates=true

--- a/launch/home/etc/services.cfg
+++ b/launch/home/etc/services.cfg
@@ -30,10 +30,10 @@ com.eclipsesource.jaxrs.swagger.config:swagger.basePath=/rest
 com.eclipsesource.jaxrs.swagger.config:swagger.info.title=openHAB REST API
 
 # Configuration of scheduled thread pool sizes
-org.eclipse.smarthome.threadpool:thingHandler=3
-org.eclipse.smarthome.threadpool:discovery=3
+org.eclipse.smarthome.threadpool:thingHandler=5
+org.eclipse.smarthome.threadpool:discovery=5
 
 # Non-scheduled thread pools can also provide a max size
-org.eclipse.smarthome.threadpool:safeCall=3
+org.eclipse.smarthome.threadpool:safeCall=10
 
 org.eclipse.smarthome.autoupdate:sendOptimisticUpdates=true


### PR DESCRIPTION
When running locally I get an error:

`Ignoring invalid configuration for pool 'safeCall': 3,10 - value must be an integer`

This fixes it, do you also see this error, is this new / expected?