### PR TITLE
Fixed spelling of 'TRÅDFRI' and added dependency on 'openhab-transport-coap'

### DIFF
--- a/features/addons-esh/src/main/feature/feature.xml
+++ b/features/addons-esh/src/main/feature/feature.xml
@@ -67,7 +67,8 @@
         </config>
     </feature>
 
-    <feature name="openhab-binding-tradfri" description="Trådfri Binding" version="${project.version}">
+    <feature name="openhab-binding-tradfri" description="TRÅDFRI Binding" version="${project.version}">
+        <feature>openhab-transport-coap</feature>
         <feature>esh-binding-tradfri</feature>
     </feature>
 


### PR DESCRIPTION
Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>