### PR TITLE
Demo items: Wrong semantic tag for basement

### DIFF
--- a/features/distro-resources/src/main/resources/items/demo.items
+++ b/features/distro-resources/src/main/resources/items/demo.items
@@ -1,6 +1,6 @@
 Group gFF           "First Floor"   <firstfloor>    ["FirstFloor"]
 Group gGF           "Ground Floor"  <groundfloor>   ["GroundFloor"]
-Group gC            "Cellar"        <cellar>        ["Cellar"]
+Group gC            "Cellar"        <cellar>        ["Basement"]
 Group Garden        "Garden"        <garden>        ["Garden"]
 Group Weather       "Weather"       <sun>
 


### PR DESCRIPTION
The correct tag in the ESH ontology is "Basement", not "Cellar".

Signed-off-by: Yannick Schaus <github@schaus.net>