### PR TITLE
added Sony Audio binding to distro

### DIFF
--- a/features/addons-esh/src/main/feature/feature.xml
+++ b/features/addons-esh/src/main/feature/feature.xml
@@ -72,6 +72,11 @@
         </config>
     </feature>
 
+    <feature name="openhab-binding-sonyaudio" description="Sony Audio Binding" version="${project.version}">
+        <feature>openhab-transport-upnp</feature>
+        <feature>esh-binding-sonyaudio</feature>
+    </feature>
+
     <feature name="openhab-binding-tradfri" description="TRÅDFRI Binding" version="${project.version}">
         <feature>openhab-transport-coap</feature>
         <feature>esh-binding-tradfri</feature>


### PR DESCRIPTION
@freke FYI - this will now be part of openHAB snapshot builds and included in the upcoming openHAB 2.4 release.

Signed-off-by: Kai Kreuzer <kai@openhab.org>