### PR TITLE
Added OpenWeatherMap binding to features

### DIFF
--- a/features/addons-esh/src/main/feature/feature.xml
+++ b/features/addons-esh/src/main/feature/feature.xml
@@ -60,6 +60,10 @@
         <feature>esh-binding-onewire</feature>
     </feature>
 
+    <feature name="openhab-binding-openweathermap" description="OpenWeatherMap Binding" version="${project.version}">
+        <feature>esh-binding-openweathermap</feature>
+    </feature>
+
     <feature name="openhab-binding-serialbutton" description="Serial Button Binding" version="${project.version}">
         <feature>openhab-transport-serial</feature>
         <feature>esh-binding-serialbutton</feature>


### PR DESCRIPTION
- Added OpenWeatherMap binding to features

Depends on https://github.com/eclipse/smarthome/pull/5694.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>