### PR TITLE
Updates to powershell scripts (fixes, added logic, etc)

### DIFF
--- a/distributions/openhab/src/main/resources/bin/backup.bat
+++ b/distributions/openhab/src/main/resources/bin/backup.bat
@@ -1,0 +1,19 @@
+@ECHO off
+SETLOCAL
+
+powershell -command "& { . .\backup.ps1; Backup-openHAB -OHDirectory %~1 -OHBackups %~2 -FileName %~3 }"
+EXIT /B 0
+
+:printArgs
+ECHO Usage: backup.bat {OHDirectory} {OHBackups} {FileName}
+ECHO OHDirectory (optional) - The openHAB distribution directory
+ECHO OHBackups   (optional) - The directory where backups are stored
+ECHO FileName    (optional) - The backup file name (found in OHBackups)
+ECHO.
+ECHO Example to backup openHAB to the default locations
+ECHO    backup.bat
+ECHO.
+ECHO Example to backup openHAB to "backup.zip" in "c:\openhab2\backups":
+ECHO    update.bat "c:\openhab2" "c:\openhab2\backups" "backup.zip" 
+ECHO.
+EXIT /B -1

--- a/distributions/openhab/src/main/resources/bin/backup.bat
+++ b/distributions/openhab/src/main/resources/bin/backup.bat
@@ -1,11 +1,30 @@
 @ECHO off
 SETLOCAL
 
-powershell -command "& { . .\backup.ps1; Backup-openHAB -OHDirectory %~1 -OHBackups %~2 -FileName %~3 }"
+IF "%1"=="?" GOTO printArgs
+IF "%1"=="\?" GOTO printArgs
+IF "%1"=="/?" GOTO printArgs
+
+SET bargs=
+
+IF NOT [%1]==[] ( SET bargs=%bargs% -MaxFiles %~1% )
+IF NOT [%2]==[] ( SET bargs=%bargs% -OHDirectory %~2% )
+IF NOT [%3]==[] ( SET bargs=%bargs% -OHBackups %~3% )
+IF NOT [%4]==[] ( SET bargs=%bargs% -FileName %~4% )
+
+CD %~dp0
+powershell -ExecutionPolicy Bypass -command "&{. .\backup.ps1; Backup-openHAB %bargs% }" 
+SET LEVEL=%ERRORLEVEL%
+
+if %LEVEL% LSS 0 (
+    PAUSE
+    EXIT /B %LEVEL%
+)
 EXIT /B 0
 
 :printArgs
-ECHO Usage: backup.bat {OHDirectory} {OHBackups} {FileName}
+ECHO Usage: backup.bat {MaxFiles} {OHDirectory} {OHBackups} {FileName}
+ECHO MaxFiles    (optional) - The maximum number of backups to keep (specify 0 for no maximum)
 ECHO OHDirectory (optional) - The openHAB distribution directory
 ECHO OHBackups   (optional) - The directory where backups are stored
 ECHO FileName    (optional) - The backup file name (found in OHBackups)
@@ -13,7 +32,7 @@ ECHO.
 ECHO Example to backup openHAB to the default locations
 ECHO    backup.bat
 ECHO.
-ECHO Example to backup openHAB to "backup.zip" in "c:\openhab2\backups":
-ECHO    update.bat "c:\openhab2" "c:\openhab2\backups" "backup.zip" 
+ECHO Example to backup openHAB to "backup.zip" in "c:\openhab2\backups" keeping at most 10 backups:
+ECHO    backup.bat 10 "c:\openhab2" "c:\openhab2\backups" "backup.zip" 
 ECHO.
 EXIT /B -1

--- a/distributions/openhab/src/main/resources/bin/backup.ps1
+++ b/distributions/openhab/src/main/resources/bin/backup.ps1
@@ -44,7 +44,8 @@ Function Backup-openHAB {
         BoxMessage "openHAB 2.x.x backup script" Magenta
         Write-Host ""
 
-        CheckForAdmin
+        # Check for admin (commented out - don't think we need it)
+        # CheckForAdmin
 
         Write-Host -ForegroundColor Cyan "Checking the specified openHAB directory"
         $OHDirectory = GetOpenHABRoot $OHDirectory

--- a/distributions/openhab/src/main/resources/bin/backup.ps1
+++ b/distributions/openhab/src/main/resources/bin/backup.ps1
@@ -1,4 +1,7 @@
-﻿Function Backup-openHAB {
+﻿#Requires -Version 5.0
+Set-StrictMode -Version Latest
+
+Function Backup-openHAB {
     <#
     .SYNOPSIS
     Backsup openHAB files.
@@ -8,60 +11,57 @@
     The directory where openHAB is installed (default: current directory).
     .PARAMETER OHBackups
     The directory to backup the files to.
-    .PARAMETER ZipFileOut
+    .PARAMETER FileName
     The name of the zip file to create
     .EXAMPLE
     Backup an openHAB instance to a zip file
     Backup-openHAB
     .EXAMPLE
     Backup the openHAB distribution in the C:\openHAB2 directory to c:\openHAB2-backup\backup.zip
-    Backup-openHAB -OHDirectory C:\openHAB2 -OHBackups c:\openHAB2-backup -ZipFileOut backup.zip
+    Backup-openHAB -OHDirectory C:\openHAB2 -OHBackups c:\openHAB2-backup -FileName backup.zip
     #>
 
     [CmdletBinding()]
     param(
-        [Parameter(ValueFromPipeline=$True)]
+        [Parameter(ValueFromPipeline = $True)]
         [string]$OHDirectory = ".",
-        [Parameter(ValueFromPipeline=$True)]
+        [Parameter(ValueFromPipeline = $True)]
         [string]$OHBackups,
-        [Parameter(ValueFromPipeline=$True)]
-        [string]$ZipFileOut
+        [Parameter(ValueFromPipeline = $True)]
+        [string]$FileName
     )
 
     begin {}
     process {
 
-        if (!([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
-            ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-            throw "This script must be run as an Administrator. Start PowerShell with the Run as Administrator option"
+        Import-Module $PSScriptRoot\common.psm1 -Force
+
+        Write-Host ""
+        BoxMessage "openHAB 2.x.x backup script" Magenta
+        Write-Host ""
+
+        CheckForAdmin
+
+        Write-Host -ForegroundColor Cyan "Checking the specified openHAB directory"
+        $OHDirectory = GetOpenHABRoot $OHDirectory
+        if ($OHDirectory -eq "") {
+            return PrintAndReturn "Could not find the userdata directory! Make sure you are in the openHAB directory or specify the -OHDirectory parameter!"
+        }
+    
+        $OHConf = "$OHDirectory\conf"
+        $OHUserdata = "$OHDirectory\userdata"
+
+        if ([string]::IsNullOrEmpty($OHBackups)) {
+            $OHBackups = "$OHDirectory\backups"
         }
 
-        Write-Host -ForegroundColor Cyan "Checking the specified openHAB directory..."
-        if (!(Test-Path "$OHDirectory\userdata") -And !(Test-Path -Path "$OHDirectory\conf")) {
-            throw "$OHDirectory\userdata doesn't exist! Make sure you are in the " +
-                "openHAB directory or specify the -OHDirectory parameter!"
-        }
-
-        if ($OHDirectory -eq '.') {$OHDirectory = pwd }
-
-        if ([Environment]::GetEnvironmentVariable("OPENHAB_CONF", "Machine")) {
-            $OHConf = [Environment]::GetEnvironmentVariable("OPENHAB_CONF", "Machine")
-        } else {
-            $OHConf = "$OHDirectory\conf"
-        }
-        if ([Environment]::GetEnvironmentVariable("OPENHAB_USERDATA", "Machine")) {
-            $OHUserdata = [Environment]::GetEnvironmentVariable("OPENHAB_USERDATA", "Machine")
-        } else {
-            $OHUserdata = "$OHDirectory\userdata"
-        }
-        if (!($OHBackups)) {
-            if ([Environment]::GetEnvironmentVariable("OPENHAB_BACKUPS", "Machine")) {
-                $OHBackups = [Environment]::GetEnvironmentVariable("OPENHAB_BACKUPS", "Machine")
-            } else {
-                $OHBackups = "$OHDirectory\backups"
-                if (!(Test-Path "$OHDirectory\backups")){
-                    mkdir "$OHBackups" | Out-Null
-                }
+        if (!(Test-Path $OHBackups -PathType Container)) {
+            try {
+                Write-Host -ForegroundColor Cyan "Creating backup directory $OHBackups"
+                CreateDirectory $OHBackups
+            }
+            catch {
+                return PrintAndReturn "Error creating backup directory $OHBackups - exiting" $_
             }
         }
 
@@ -69,42 +69,94 @@
         Write-Host -ForegroundColor Yellow "Using $OHUserdata as userdata folder"
         Write-Host -ForegroundColor Yellow "Using $OHBackups as backups folder"
 
-        $TempDir=([Environment]::GetEnvironmentVariable("TEMP", "Machine"))+"\openhab"
-        New-Item $TempDir -Type directory -Force | Out-Null
+        $TempDir = "$(GetOpenHABTempDirectory)\backup"
 
-        $VersionLine = Get-Content "$OHDirectory\userdata\etc\version.properties" | Where-Object { $_.Contains("openhab-distro")}
-        $CurrentVersionIndex = $VersionLine.IndexOf(":")
-        $CurrentVersion = $VersionLine.Substring($currentVersionIndex + 2)
-        $timestamp = Get-Date -Format yyyyMMddHHmm
-        Write-Output "version=$CurrentVersion" | Set-Content "$TempDir\backup.properties"
-        Write-Output "timestamp=$timestamp" | Add-Content "$TempDir\backup.properties"
-        Write-Output "user=openhab" | Add-Content "$TempDir\backup.properties"
-        Write-Output "group=openhab" | Add-Content "$TempDir\backup.properties"
-
-        Write-Host -ForegroundColor Cyan "Copying userdata and conf folder contents to temp directory"
-        mkdir "$TempDir\userdata" | Out-Null
-        Copy-Item $OHUserdata $TempDir -Recurse -Force
-        mkdir "$TempDir\conf" | Out-Null
-        Copy-Item $OHConf $TempDir -Recurse -Force
-
-        Write-Host -ForegroundColor Cyan "Removing unnecessary files..."
-        foreach($FileName in Get-Content "$OHDirectory\runtime\bin\userdata_sysfiles.lst"){
-            Remove-Item ($TempDir + '\userdata\etc\' + $FileName) -ErrorAction SilentlyContinue
+        try {
+            Write-Host -ForegroundColor Cyan "Creating temporary backup directory $TempDir"
+            CreateDirectory $TempDir
         }
-        Remove-Item ($TempDir + '\userdata\cache') -Recurse -ErrorAction SilentlyContinue
-        Remove-Item ($TempDir + '\userdata\tmp') -Recurse -ErrorAction SilentlyContinue
+        catch {
+            return PrintAndReturn "Error creating temporary backup directory $TempDir - exiting" $_
+        }
 
-        Write-Host -ForegroundColor Cyan "Removing backup folder from backup userdata if it exists..."
-        if (Test-Path "$TempDir\userdata\backups") {Remove-Item "$TempDir\userdata\backups" -Recurse -ErrorAction SilentlyContinue}
+        try {
+            $CurrentVersion = GetOpenHABVersion $OHDirectory
+            if ($CurrentVersion -eq "") {
+                return PrintAndReturn "Can't get the current openhab version from $OHDirectory - exiting"
+            }
 
-        Write-Host -ForegroundColor Cyan "Zipping up files..."
-        Add-Type -AssemblyName System.IO.Compression.FileSystem
-        if (!($ZipFileOut)) {$ZipFileOut = "$OHBackups\openhab2-backup-$timestamp.zip"}
-        [System.IO.Compression.ZipFile]::CreateFromDirectory($TempDir, $ZipFileOut)
+            $timestamp = Get-Date -UFormat "%y_%m_%d-%H_%M_%S"
+            $BackupProperites = "$TempDir\backup.properties"
+            try {
+                CreateFile $BackupProperites
+                Write-Output "version=$CurrentVersion" -ErrorAction Stop | Add-Content $BackupProperites -ErrorAction Stop
+                Write-Output "timestamp=$timestamp" -ErrorAction Stop | Add-Content $BackupProperites -ErrorAction Stop 
+                Write-Output "user=openhab" -ErrorAction Stop | Add-Content $BackupProperites -ErrorAction Stop
+                Write-Output "group=openhab" -ErrorAction Stop | Add-Content $BackupProperites -ErrorAction Stop
+            }
+            catch {
+                return PrintAndReturn "Can't create the temporary backup.properties file in $TempDir - exiting" $_
+            }
 
-        Write-Host -ForegroundColor Cyan "Removing temp files..."
-        Remove-Item $TempDir -Recurse -ErrorAction SilentlyContinue
+            Write-Host -ForegroundColor Cyan "Copying userdata and conf folder contents to temp directory"
+            try {
+                Copy-Item $OHUserdata $TempDir -Recurse
+                Copy-Item $OHConf $TempDir -Recurse
+            }
+            catch {
+                return PrintAndReturn "Can't copy the userdata/conf directory to the temporary directory $TempDir - exiting" $_
+            }
 
-        Write-Host -ForegroundColor Green "Backup created at $OHBackups\openhab2-backup-$timestamp.zip"
+            try {
+                Write-Host -ForegroundColor Cyan "Removing unnecessary files"
+                foreach ($sysFile in Get-Content "$OHDirectory\runtime\bin\userdata_sysfiles.lst") {
+                    DeleteIfExists "$TempDir\userdata\etc\$sysFile"
+                }
+                DeleteIfExists "$TempDir\userdata\cache"
+                DeleteIfExists "$TempDir\userdata\tmp"
+
+                Write-Host -ForegroundColor Cyan "Removing backup folder from backup userdata if it exists"
+                DeleteIfExists "$TempDir\userdata\backups"
+            }
+            catch {
+                return PrintAndReturn "Error removing unnecessary files from $TempDir - exiting" $_
+            }
+
+            if ([string]::IsNullOrEmpty($FileName)) {
+                $FileName = "$OHBackups\openhab2-backup-$timestamp.zip"
+            }
+
+            Write-Host -ForegroundColor Cyan "Zipping up files to $FileName"
+            try {
+                Compress-Archive -Path "$TempDir\*" -DestinationPath $FileName -ErrorAction Stop
+            }
+            catch {
+                return PrintAndReturn "Error zipping up files to $FileName - exiting" $_
+            }
+
+            Write-Host -ForegroundColor Green "Backup created at $FileName"
+
+        }
+        finally {
+            $parent = (Get-Item $TempDir).Parent.FullName
+
+            try {
+                Write-Host -ForegroundColor Cyan "Removing temporary directory $TempDir"
+                DeleteIfExists $TempDir
+            }
+            catch {
+                Write-Host -ForegroundColor Red "Could not delete $TempDir - delete it manually"
+            }
+
+            try {
+                if (-Not (Test-Path "$parent\*")) {
+                    Write-Host -ForegroundColor Cyan "Removing temporary directory $parent"
+                    DeleteIfExists $parent
+                }
+            }
+            catch {
+                Write-Host -ForegroundColor Red "Could not delete $parent - delete it manually"
+            }
+       }
     }
 }

--- a/distributions/openhab/src/main/resources/bin/backup.ps1
+++ b/distributions/openhab/src/main/resources/bin/backup.ps1
@@ -13,6 +13,8 @@ Function Backup-openHAB {
     The directory to backup the files to.
     .PARAMETER FileName
     The name of the zip file to create
+    .PARAMETER MaxFiles
+    The maximum number of files to keep
     .EXAMPLE
     Backup an openHAB instance to a zip file
     Backup-openHAB
@@ -28,7 +30,9 @@ Function Backup-openHAB {
         [Parameter(ValueFromPipeline = $True)]
         [string]$OHBackups,
         [Parameter(ValueFromPipeline = $True)]
-        [string]$FileName
+        [string]$FileName,
+        [Parameter(ValueFromPipeline = $True)]
+        [int]$MaxFiles
     )
 
     begin {}
@@ -45,29 +49,43 @@ Function Backup-openHAB {
         Write-Host -ForegroundColor Cyan "Checking the specified openHAB directory"
         $OHDirectory = GetOpenHABRoot $OHDirectory
         if ($OHDirectory -eq "") {
-            return PrintAndReturn "Could not find the userdata directory! Make sure you are in the openHAB directory or specify the -OHDirectory parameter!"
+            exit PrintAndReturn "Could not find the userdata directory! Make sure you are in the openHAB directory or specify the -OHDirectory parameter!"
         }
     
-        $OHConf = "$OHDirectory\conf"
-        $OHUserdata = "$OHDirectory\userdata"
+        $OHConf = GetOpenHABDirectory "OPENHAB_CONF" "$OHDirectory\conf"
+        $OHUserData = GetOpenHABDirectory "OPENHAB_USERDATA" "$OHDirectory\userdata"
+        $OHRuntime = GetOpenHABDirectory "OPENHAB_RUNTIME" "$OHDirectory\runtime"
 
         if ([string]::IsNullOrEmpty($OHBackups)) {
-            $OHBackups = "$OHDirectory\backups"
+            $OHBackups = GetOpenHABDirectory "OPENHAB_BACKUPS" "$OHDirectory\backups"
         }
 
-        if (!(Test-Path $OHBackups -PathType Container)) {
+        if (-NOT (Test-Path -Path $OHConf -PathType Container)) {
+            exit PrintAndReturn "Configuration directory does not exist:  $OHConf"
+        }
+
+        if (-NOT (Test-Path -Path $OHUserData -PathType Container)) {
+            exit PrintAndReturn "Userdata directory does not exist:  $OHUserData"
+        }
+        
+        if (-NOT (Test-Path -Path $OHRuntime -PathType Container)) {
+            exit PrintAndReturn "Runtime directory does not exist:  $OHRuntime"
+        }
+        
+        if (-NOT (Test-Path -Path $OHBackups -PathType Container)) {
             try {
                 Write-Host -ForegroundColor Cyan "Creating backup directory $OHBackups"
                 CreateDirectory $OHBackups
             }
             catch {
-                return PrintAndReturn "Error creating backup directory $OHBackups - exiting" $_
+                exit PrintAndReturn "Error creating backup directory $OHBackups - exiting" $_
             }
         }
 
         Write-Host -ForegroundColor Yellow "Using $OHConf as conf folder"
-        Write-Host -ForegroundColor Yellow "Using $OHUserdata as userdata folder"
+        Write-Host -ForegroundColor Yellow "Using $OHUserData as userdata folder"
         Write-Host -ForegroundColor Yellow "Using $OHBackups as backups folder"
+        Write-Host -ForegroundColor Yellow "Using $OHRuntime as runtime folder"
 
         $TempDir = "$(GetOpenHABTempDirectory)\backup"
 
@@ -76,13 +94,13 @@ Function Backup-openHAB {
             CreateDirectory $TempDir
         }
         catch {
-            return PrintAndReturn "Error creating temporary backup directory $TempDir - exiting" $_
+            exit PrintAndReturn "Error creating temporary backup directory $TempDir - exiting" $_
         }
 
         try {
-            $CurrentVersion = GetOpenHABVersion $OHDirectory
+            $CurrentVersion = GetOpenHABVersion $OHUserData
             if ($CurrentVersion -eq "") {
-                return PrintAndReturn "Can't get the current openhab version from $OHDirectory - exiting"
+                exit PrintAndReturn "Can't get the current openhab version from $OHDirectory - exiting"
             }
 
             $timestamp = Get-Date -UFormat "%y_%m_%d-%H_%M_%S"
@@ -95,35 +113,52 @@ Function Backup-openHAB {
                 Write-Output "group=openhab" -ErrorAction Stop | Add-Content $BackupProperites -ErrorAction Stop
             }
             catch {
-                return PrintAndReturn "Can't create the temporary backup.properties file in $TempDir - exiting" $_
+                exit PrintAndReturn "Can't create the temporary backup.properties file in $TempDir - exiting" $_
             }
 
             Write-Host -ForegroundColor Cyan "Copying userdata and conf folder contents to temp directory"
             try {
-                Copy-Item $OHUserdata $TempDir -Recurse
-                Copy-Item $OHConf $TempDir -Recurse
+                Copy-Item $OHUserData $TempDir -Recurse -ErrorAction Stop
+                Copy-Item $OHConf $TempDir -Recurse -ErrorAction Stop
             }
             catch {
-                return PrintAndReturn "Can't copy the userdata/conf directory to the temporary directory $TempDir - exiting" $_
+                exit PrintAndReturn "Can't copy the userdata/conf directory to the temporary directory $TempDir - exiting" $_
             }
 
             try {
                 Write-Host -ForegroundColor Cyan "Removing unnecessary files"
-                foreach ($sysFile in Get-Content "$OHDirectory\runtime\bin\userdata_sysfiles.lst") {
+                foreach ($sysFile in Get-Content "$OHRuntime\bin\userdata_sysfiles.lst") {
                     DeleteIfExists "$TempDir\userdata\etc\$sysFile"
                 }
-                DeleteIfExists "$TempDir\userdata\cache"
-                DeleteIfExists "$TempDir\userdata\tmp"
+                DeleteIfExists "$TempDir\userdata\cache" $True
+                DeleteIfExists "$TempDir\userdata\tmp" $True
 
                 Write-Host -ForegroundColor Cyan "Removing backup folder from backup userdata if it exists"
-                DeleteIfExists "$TempDir\userdata\backups"
+                DeleteIfExists "$TempDir\userdata\backups" $True
             }
             catch {
-                return PrintAndReturn "Error removing unnecessary files from $TempDir - exiting" $_
+                exit PrintAndReturn "Error removing unnecessary files from $TempDir - exiting" $_
             }
 
             if ([string]::IsNullOrEmpty($FileName)) {
                 $FileName = "$OHBackups\openhab2-backup-$timestamp.zip"
+            } else {
+                if (-NOT $FileName.EndsWith(".zip")) {
+                    $FileName = $FileName + ".zip";
+                }
+
+                if ((Split-Path -Path $FileName) -eq "") {
+                    $FileName = "$OHBackups\$FileName"
+                }
+            }
+
+            if (Test-Path -Path $FileName) {
+                Write-Host -ForegroundColor Yellow "Backup file $FileName already exists!"
+                $confirmation = Read-Host "Do you wish to overwrite that file? [y/N]"
+                if ($confirmation -ne 'y') {
+                    exit PrintAndReturn "Cancelling backup"
+                }
+                DeleteIfExists $FileName
             }
 
             Write-Host -ForegroundColor Cyan "Zipping up files to $FileName"
@@ -131,18 +166,29 @@ Function Backup-openHAB {
                 Compress-Archive -Path "$TempDir\*" -DestinationPath $FileName -ErrorAction Stop
             }
             catch {
-                return PrintAndReturn "Error zipping up files to $FileName - exiting" $_
+                exit PrintAndReturn "Error zipping up files to $FileName - exiting" $_
             }
 
             Write-Host -ForegroundColor Green "Backup created at $FileName"
 
+            if ($MaxFiles -gt 0) {
+                Write-Host -ForegroundColor Cyan "Keeping only the last $MaxFiles backups"
+                Get-ChildItem -Path $OHBackups -Filter *.zip | Sort LastWriteTime -Descending | Select -Skip $MaxFiles | %{
+                    Write-Host -ForegroundColor Cyan "Deleting $_"
+                    DeleteIfExists $_.FullName
+                }
+            }
+        }
+        catch {
+            # No printandthrows so we are catching an unknown error
+            exit PrintAndReturn "Exception occurred backing up file" $_
         }
         finally {
             $parent = (Get-Item $TempDir).Parent.FullName
 
             try {
                 Write-Host -ForegroundColor Cyan "Removing temporary directory $TempDir"
-                DeleteIfExists $TempDir
+                DeleteIfExists $TempDir $True
             }
             catch {
                 Write-Host -ForegroundColor Red "Could not delete $TempDir - delete it manually"
@@ -151,7 +197,7 @@ Function Backup-openHAB {
             try {
                 if (-Not (Test-Path "$parent\*")) {
                     Write-Host -ForegroundColor Cyan "Removing temporary directory $parent"
-                    DeleteIfExists $parent
+                    DeleteIfExists $parent $True
                 }
             }
             catch {

--- a/distributions/openhab/src/main/resources/bin/common.psm1
+++ b/distributions/openhab/src/main/resources/bin/common.psm1
@@ -1,0 +1,173 @@
+#Requires -Version 5.0
+Set-StrictMode -Version Latest
+
+function CheckForAdmin() {
+    if (!([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+        ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        throw "This script must be run as an Administrator. Start PowerShell with the Run as Administrator option"
+    }
+}
+function GetOpenHABRoot() {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $dirName
+    )
+
+    function IsOpenHabRoot() {
+        param(
+            [Parameter(Mandatory = $true)]    
+            [string] $dirName
+        )
+        return (Test-Path "$dirName\userdata") -And (Test-Path -Path "$dirName\conf");
+    }
+    
+    
+    if (-Not (IsOpenHabRoot $dirName)) {
+        $dirName = $PSScriptRoot;
+        while ($dirName -ne "" -and -not(IsOpenHabRoot $dirName)) {
+            $dirName = Split-Path -Path $dirName -Parent
+        }
+    }
+
+    return $dirName
+}
+
+function CreateDirectory() {
+    param(
+        [Parameter(Mandatory = $True)]
+        [string] $itemName
+    )
+
+    New-Item -Path $itemName -ItemType directory -Force -Confirm:$False -ErrorAction Stop | Out-Null
+}
+
+function CreateFile() {
+    param(
+        [Parameter(Mandatory = $True)]
+        [string] $itemName
+    )
+
+    New-Item -Path $itemName -ItemType file -Force -Confirm:$False -ErrorAction Stop | Out-Null
+}
+
+function DeleteIfExists() {
+    param(
+        [Parameter(Mandatory = $True)]
+        [string] $itemName
+    )
+
+    if (Test-Path $itemName -PathType Container) {
+        Remove-Item $itemName -Force -Recurse -Confirm:$False -ErrorAction Stop | Out-Null
+    }
+    ElseIf (Test-Path $itemName) {
+        Remove-Item $itemName -Force -Confirm:$False -ErrorAction Stop | Out-Null
+    }
+}
+
+function GetOpenHABVersion() {
+    param(
+        [Parameter(Mandatory = $True)]
+        [string] $OHDirectory
+    )
+
+    if (Test-Path "$OHDirectory\userdata\etc\version.properties" -ErrorAction SilentlyContinue) {
+        $VersionLine = Get-Content "$OHDirectory\userdata\etc\version.properties" -ErrorAction SilentlyContinue | Where-Object { $_.Contains("openhab-distro")} -ErrorAction SilentlyContinue
+        $CurrentVersionIndex = $VersionLine.IndexOf(":")
+        if ($CurrentVersionIndex -gt -1) {
+            return $VersionLine.Substring($currentVersionIndex + 2)
+        }
+    }
+
+    return "";
+}
+
+function GetOpenHABTempDirectory() {
+    return "$([Environment]::GetEnvironmentVariable("TEMP", "Machine"))\openhab"
+}
+
+function CheckOpenHABRunning() {
+    $m = (Get-WmiObject Win32_Process -Filter "name = 'java.exe'" |
+            Where-Object { $_.CommandLine.Contains("openhab") } | Measure-Object)
+    if ($m.Count -gt 0) {
+        throw "openHAB seems to be running, stop it before running this update script"
+    }
+
+}
+function GetRelativePath() {
+    param(
+        [Parameter(Mandatory = $True)]
+        [string] $root,
+        [Parameter(Mandatory = $True)]
+        [string] $absPath
+    )
+
+    $tmp = Get-Location -ErrorAction Stop 
+    Set-Location $root -ErrorAction Stop 
+    try {
+        return Resolve-Path $absPath -Relative -ErrorAction Stop 
+    }
+    finally {
+        Set-Location $tmp -ErrorAction Stop 
+    }
+}
+
+function PrintAndReturn {
+    param(
+        [Parameter(Mandatory = $True)]
+        [string] $msg,
+        [Parameter(Mandatory = $False)]
+        [System.Management.Automation.ErrorRecord] $ex,
+        [Parameter(Mandatory = $False)]
+        [int] $rc
+    )
+    BoxMessage $msg Red
+
+    if ($ex) {
+        Write-Error $ex
+    }
+
+    if ($rc) {
+        return $rc
+    }
+    return -1
+}
+
+function PrintAndThrow {
+    param(
+        [Parameter(Mandatory = $True)]
+        [string] $msg,
+        [Parameter(Mandatory = $True)]
+        [System.Management.Automation.ErrorRecord] $ex
+    )
+    BoxMessage $msg Red
+    Write-Error $ex
+
+    throw $ex.Exception
+}
+
+function BoxMessage {
+    param(
+        [Parameter(Mandatory = $True)]
+        [string] $msg,
+        [Parameter(Mandatory = $True)]
+        [System.ConsoleColor] $color
+
+    )
+    $pad = "#".PadRight($msg.Length + 6, "#")
+    Write-Host -ForegroundColor $color $pad
+    Write-Host -ForegroundColor $color "#  $msg  #"
+    Write-Host -ForegroundColor $color $pad
+}
+
+Export-ModuleMember -Function "BoxMessage"
+Export-ModuleMember -Function "CheckForAdmin"
+Export-ModuleMember -Function "CheckOpenHABRunning"
+Export-ModuleMember -Function "CreateDirectory"
+Export-ModuleMember -Function "CreateFile"
+Export-ModuleMember -Function "DeleteIfExists"
+Export-ModuleMember -Function "GetOpenHABRoot"
+Export-ModuleMember -Function "GetOpenHABTempDirectory"
+Export-ModuleMember -Function "GetOpenHABVersion"
+Export-ModuleMember -Function "GetRelativePath"
+Export-ModuleMember -Function "PrintAndReturn"
+Export-ModuleMember -Function "PrintAndThrow"

--- a/distributions/openhab/src/main/resources/bin/restore.bat
+++ b/distributions/openhab/src/main/resources/bin/restore.bat
@@ -1,11 +1,31 @@
 @ECHO off
 SETLOCAL
 
+IF "%1"=="?" GOTO printArgs
+IF "%1"=="\?" GOTO printArgs
+IF "%1"=="/?" GOTO printArgs
+
+
 IF NOT [%~4]==[] IF NOT "%~4"=="true" IF NOT "%~4"=="false" GOTO printArgs
 
 SET autoConfirm=False
 IF "%~4"=="true" SET autoConfirm=True
-powershell -command "& { . .\restore.ps1; Restore-openHAB -OHDirectory %~1 -OHBackups %~2 -FileName %~3 -AutoConfirm $%autoConfirm% }"
+
+SET rargs=
+
+IF NOT [%1]==[] ( SET rargs=%rargs% -OHDirectory %~1% )
+IF NOT [%2]==[] ( SET rargs=%rargs% -OHBackups %~2% )
+IF NOT [%3]==[] ( SET rargs=%rargs% -FileName %~3% )
+
+CD %~dp0
+powershell -ExecutionPolicy Bypass -command "& { . .\restore.ps1; Restore-openHAB %rargs% -AutoConfirm $%autoConfirm% }"
+SET LEVEL=%ERRORLEVEL%
+
+if %LEVEL% LSS 0 (
+    PAUSE
+    EXIT /B %LEVEL%
+)
+
 EXIT /B 0
 
 :printArgs
@@ -19,6 +39,6 @@ ECHO Example to restore openHAB from the latest backup in the default locations
 ECHO    restore.bat
 ECHO.
 ECHO Example to restore openHAB from the "backup.zip" found in "c:\openhab2\backups" with auto confirming:
-ECHO    update.bat "c:\openhab2" "c:\openhab2\backups" "backup.zip" true 
+ECHO    restore.bat "c:\openhab2" "c:\openhab2\backups" "backup.zip" true 
 ECHO.
 EXIT /B -1

--- a/distributions/openhab/src/main/resources/bin/restore.bat
+++ b/distributions/openhab/src/main/resources/bin/restore.bat
@@ -1,0 +1,24 @@
+@ECHO off
+SETLOCAL
+
+IF NOT [%~4]==[] IF NOT "%~4"=="true" IF NOT "%~4"=="false" GOTO printArgs
+
+SET autoConfirm=False
+IF "%~4"=="true" SET autoConfirm=True
+powershell -command "& { . .\restore.ps1; Restore-openHAB -OHDirectory %~1 -OHBackups %~2 -FileName %~3 -AutoConfirm $%autoConfirm% }"
+EXIT /B 0
+
+:printArgs
+ECHO Usage: restore.bat {OHDirectory} {OHBackups} {FileName} {AutoConfirm}
+ECHO OHDirectory (optional) - The openHAB distribution directory
+ECHO OHBackups   (optional) - The directory where backups are stored
+ECHO FileName    (optional) - The backup file name (found in OHBackups)
+ECHO AutoConfrim (optional) - "true" to automatically confirm restoration, "false" otherwise
+ECHO.
+ECHO Example to restore openHAB from the latest backup in the default locations
+ECHO    restore.bat
+ECHO.
+ECHO Example to restore openHAB from the "backup.zip" found in "c:\openhab2\backups" with auto confirming:
+ECHO    update.bat "c:\openhab2" "c:\openhab2\backups" "backup.zip" true 
+ECHO.
+EXIT /B -1

--- a/distributions/openhab/src/main/resources/bin/restore.ps1
+++ b/distributions/openhab/src/main/resources/bin/restore.ps1
@@ -1,0 +1,211 @@
+﻿#Requires -Version 5.0
+Set-StrictMode -Version Latest
+
+Function Restore-openHAB {
+    <#
+    .SYNOPSIS
+    Restores openHAB files from a backup file.
+    .DESCRIPTION
+    The Restore-openHAB function performs the necessary tasks to restore openHAB from a backup file.
+    .PARAMETER OHDirectory
+    The directory where openHAB is installed (default: current directory).
+    .PARAMETER OHBackups
+    The directory where backup the files are.
+    .PARAMETER FileName
+    The name of the backup file to use (do not specify to use the latest)
+    .PARAMETER AutoConfirm
+    Whether to auto confirm ($true) replacement of files (used for headless mode)
+    .EXAMPLE
+    Restore an openHAB instance from the latest backup file
+    Restore-openHAB
+    .EXAMPLE
+    Restore the openHAB distribution in the C:\openHAB2 directory from c:\openHAB2-backup\backup.zip without any user interaction
+    Restore-openHAB -OHDirectory C:\openHAB2 -OHBackups c:\openHAB2-backup -FileName backup.zip -AutoConfirm $true
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline = $True)]
+        [string]$OHDirectory = ".",
+        [Parameter(ValueFromPipeline = $True)]
+        [string]$OHBackups = "",
+        [Parameter(ValueFromPipeline = $True)]
+        [string]$FileName = "",
+        [Parameter(ValueFromPipeline = $True)]
+        [boolean]$AutoConfirm = $False
+    )
+
+    begin {}
+    process {
+
+        Import-Module $PSScriptRoot\common.psm1 -Force
+
+        Write-Host ""
+        BoxMessage "openHAB 2.x.x restore script" Magenta
+        Write-Host ""
+        
+        try {
+            $StartDir = Get-Location -ErrorAction Stop 
+        }
+        catch {
+            return PrintAndReturn "Can't retrieve the current location - exiting" $_
+        }
+
+        CheckForAdmin
+        CheckOpenHABRunning
+
+        Write-Host -ForegroundColor Cyan "Checking the specified openHAB directory"
+        $OHDirectory = GetOpenHABRoot $OHDirectory
+        if ($OHDirectory -eq "") {
+            return PrintAndReturn "Could not find the userdata directory! Make sure you are in the openHAB directory or specify the -OHDirectory parameter!"
+        }
+    
+        $OHConf = "$OHDirectory\conf"
+        $OHUserdata = "$OHDirectory\userdata"
+
+        if (([string]::IsNullOrEmpty($OHBackups))) {
+            $OHBackups = "$OHDirectory\backups"
+        }
+
+        if ([string]::IsNullOrEmpty($FileName)) {
+            $FileName = Get-ChildItem -Path $OHBackups -Filter *.zip -Name | Sort-Object -desc | Select-Object -First 1
+        }
+
+        if ([string]::IsNullOrEmpty($FileName)) {
+            throw "No backup filename was specified and no files were found in the $OHBackups - ending"
+        }
+
+        Write-Host -ForegroundColor Cyan "Changing location to $OHDirectory"
+        try {
+            Set-Location -Path $OHDirectory
+        }
+        catch {
+            return PrintAndReturn "Could not change location to $OHDirectory - exiting" $_
+        }
+
+        $TempDir = "$(GetOpenHABTempDirectory)\restore"
+        Write-Host -ForegroundColor Cyan "Creating temporary restore directort $TempDir"
+        try {
+            CreateDirectory $TempDir
+        }
+        catch {
+            return PrintAndReturn "Could not create directory $TempDir - exiting" $_
+        }
+
+        Write-Host -ForegroundColor Yellow "Using $OHConf as conf folder"
+        Write-Host -ForegroundColor Yellow "Using $OHUserdata as userdata folder"
+        Write-Host -ForegroundColor Yellow "Using $OHBackups as backups folder"
+        Write-Host -ForegroundColor Yellow "Using $TempDir as temporary restore directory"
+
+        $ArchiveName = Join-Path $OHBackups $FileName
+
+        try {
+            try {
+                Expand-Archive -Path $ArchiveName -DestinationPath $TempDir -ErrorAction Stop
+            }
+            catch {
+                return PrintAndReturn "Could not unzip $ArchiveName to $TempDir - exiting" $_
+            }
+
+            try {
+                Get-Content "$TempDir\backup.properties" -ErrorAction Stop | ForEach-Object {
+                    $idx = $_.IndexOf("=")
+                    if ($idx -ge 0) {
+                        $propName = $_.Substring(0, $idx)
+                        $propValue = $_.Substring($idx + 1);
+                        if ($propName -eq "version") {
+                            $BackupVersion = $propValue
+                        }
+                        ElseIf ($propName -eq "timestamp") {
+                            $BackupTime = $propValue
+                        }
+                        ElseIf ($propName -eq "user") {
+                            $OHUser = $propValue
+                        }
+                        ElseIf ($propName -eq "group") {
+                            $OHGroup = $propValue
+                        }
+                    }
+                }
+            }
+            catch {
+                return PrintAndReturn "Error occurred reading/processing $TempDir\backup.properties - exiting" $_
+            }
+
+            $CurrentVersion = GetOpenHABVersion $OHDirectory
+
+            Write-Host ""
+            Write-Host -ForegroundColor Cyan " Backup Information:"
+            Write-Host -ForegroundColor Cyan " -------------------"
+            Write-Host -ForegroundColor Cyan " Backup File            | " -NoNewline
+            Write-Host -ForegroundColor Yellow $FileName
+            Write-Host -ForegroundColor Cyan " Backup Version         | " -NoNewline
+            Write-Host -ForegroundColor Yellow "$BackupVersion (You are on $CurrentVersion)"
+            Write-Host -ForegroundColor Cyan " Backup Timestamp       | " -NoNewline
+            Write-Host -ForegroundColor Yellow $BackupTime
+            Write-Host -ForegroundColor Cyan " Config belongs to user | " -NoNewline
+            Write-Host -ForegroundColor Yellow $OHUser
+            Write-Host -ForegroundColor Cyan "             from group | " -NoNewline
+            Write-Host -ForegroundColor Yellow $OHGroup
+            Write-Host ""
+            Write-Host -ForegroundColor Cyan "Any existing files with the same name will be replaced."
+            Write-Host -ForegroundColor Cyan "Any file without a replacement will be deleted."
+            Write-Host ""
+    
+            if (-Not $AutoConfirm) {
+                $confirmation = Read-Host "Okay to Continue? [y/N]"
+                if ($confirmation -ne 'y') {
+                    return PrintAndReturn "Cancelling restore"
+                }
+            }
+
+            Write-Host -ForegroundColor Cyan "Copying the $TempDir\conf to $OHDirectory"
+            try {
+                # Replace the entire directory
+                DeleteIfExists $OHConf
+                Copy-Item -Path "$TempDir\conf" -Destination $OHDirectory -Force -Recurse
+            }
+            catch {
+                return PrintAndReturn "Error copy $TempDir\conf to $OHDirectory - exiting" $_
+            }
+
+            Write-Host -ForegroundColor Cyan "Copying the $TempDir\userdata to $OHDirectory"
+            try {
+                # Remove everything not in the 'etc' directory
+                # Will overwrite existing files in 'etc' leaving any non-match (ie new) files intact
+                Get-ChildItem -Path $OHUserData -Recurse -ErrorAction Stop | Where-Object FullName -NotMatch ".*\\etc\\*.*" | ForEach-Object ($_) { 
+                    DeleteIfExists $_.fullname
+                    Copy-Item -Path "$TempDir\userdata" -Destination $OHDirectory -Force -Recurse -ErrorAction Stop
+                }
+            }
+            catch {
+                return PrintAndReturn "Error copy $TempDir\userdata to $OHDirectory - exiting" $_
+            }
+
+            Write-Host -ForegroundColor Green "Restore has completed"
+        }
+        finally {
+            $parent = (Get-Item $TempDir).Parent.FullName
+            try {
+                Write-Host -ForegroundColor Cyan "Removing temporary directory $TempDir"
+                DeleteIfExists $TempDir
+            }
+            catch {
+                Write-Host -ForegroundColor Red "Could not delete $TempDir - delete it manually"
+            }
+
+            try {
+                if (-Not (Test-Path "$parent\*")) {
+                    Write-Host -ForegroundColor Cyan "Removing temporary directory $parent"
+                    DeleteIfExists $parent
+                }
+            }
+            catch {
+                Write-Host -ForegroundColor Red "Could not delete $parent - delete it manually"
+            }
+
+            Write-Host -ForegroundColor Cyan "Setting location back to $StartDir"
+            Set-Location -Path $StartDir  -ErrorAction Continue
+        }
+    }
+}

--- a/distributions/openhab/src/main/resources/bin/restore.ps1
+++ b/distributions/openhab/src/main/resources/bin/restore.ps1
@@ -51,8 +51,12 @@ Function Restore-openHAB {
             exit PrintAndReturn "Can't retrieve the current location - exiting" $_
         }
 
-        CheckForAdmin
+        # Check for admin (commented out - don't think we need it)
+        # CheckForAdmin
+
+        # Check for openhab running
         CheckOpenHABRunning
+
 
         Write-Host -ForegroundColor Cyan "Checking the specified openHAB directory"
         $OHDirectory = GetOpenHABRoot $OHDirectory

--- a/distributions/openhab/src/main/resources/bin/update.bat
+++ b/distributions/openhab/src/main/resources/bin/update.bat
@@ -1,13 +1,26 @@
 @ECHO off
 SETLOCAL
 
-IF [%~1]==[] GOTO printArgs
+IF "%1"=="?" GOTO printArgs
+IF "%1"=="\?" GOTO printArgs
+IF "%1"=="/?" GOTO printArgs
+
 IF NOT [%~2]==[] IF NOT "%~2"=="true" IF NOT "%~2"=="false" GOTO printArgs
 
-SET snapshot=False
-if "%~2"=="true" SET snapshot=True
+SET uargs=
+IF NOT [%1]==[] ( SET uargs=%uargs% -OHVersion %~1% )
 
-powershell -command "& { . .\update.ps1; Update-openHAB -OHVersion %~1 -Snapshot $%snapshot% }"
+SET snapshot=False
+IF "%~2"=="true" SET snapshot=True
+
+CD %~dp0
+powershell -ExecutionPolicy Bypass -command "& { . .\update.ps1; Update-openHAB %uargs% -Snapshot $%snapshot% }"
+SET LEVEL=%ERRORLEVEL%
+
+if %LEVEL% LSS 0 (
+    PAUSE
+    EXIT /B %LEVEL%
+)
 EXIT /B 0
 
 :printArgs
@@ -15,10 +28,10 @@ ECHO Usage: update.bat {OHVersion} [{Snapshot}]
 ECHO OHVersion (required) - The version you want to update (2.3, 2.4, etc)
 ECHO Snapshot  (optional) - "true" if snapshot, "false" or not specified for stable
 ECHO.
-ECHO Example to update to OH version 2.3 stable:
-ECHO    update.bat 2.3
+ECHO Example to update to OH version 2.3.0 stable:
+ECHO    update.bat 2.3.0
 ECHO.
-ECHO Example to update to OH version 2.3 snapshot:
-ECHO    update.bat 2.3 true
+ECHO Example to update to OH version 2.3.0 snapshot:
+ECHO    update.bat 2.3.0 true
 ECHO.
 EXIT /B -1

--- a/distributions/openhab/src/main/resources/bin/update.bat
+++ b/distributions/openhab/src/main/resources/bin/update.bat
@@ -5,16 +5,11 @@ IF "%1"=="?" GOTO printArgs
 IF "%1"=="\?" GOTO printArgs
 IF "%1"=="/?" GOTO printArgs
 
-IF NOT [%~2]==[] IF NOT "%~2"=="true" IF NOT "%~2"=="false" GOTO printArgs
-
 SET uargs=
 IF NOT [%1]==[] ( SET uargs=%uargs% -OHVersion %~1% )
 
-SET snapshot=False
-IF "%~2"=="true" SET snapshot=True
-
 CD %~dp0
-powershell -ExecutionPolicy Bypass -command "& { . .\update.ps1; Update-openHAB %uargs% -Snapshot $%snapshot% }"
+powershell -ExecutionPolicy Bypass -command "& { . .\update.ps1; Update-openHAB %uargs% }"
 SET LEVEL=%ERRORLEVEL%
 
 if %LEVEL% LSS 0 (
@@ -24,14 +19,16 @@ if %LEVEL% LSS 0 (
 EXIT /B 0
 
 :printArgs
-ECHO Usage: update.bat {OHVersion} [{Snapshot}]
+ECHO Usage: update.bat {OHVersion}
 ECHO OHVersion (required) - The version you want to update (2.3, 2.4, etc)
-ECHO Snapshot  (optional) - "true" if snapshot, "false" or not specified for stable
 ECHO.
 ECHO Example to update to OH version 2.3.0 stable:
 ECHO    update.bat 2.3.0
 ECHO.
 ECHO Example to update to OH version 2.3.0 snapshot:
-ECHO    update.bat 2.3.0 true
+ECHO    update.bat 2.3.0-SNAPSHOT
+ECHO.
+ECHO Example to update to OH version 2.4.0 milestone:
+ECHO    update.bat 2.4.0-M6
 ECHO.
 EXIT /B -1

--- a/distributions/openhab/src/main/resources/bin/update.bat
+++ b/distributions/openhab/src/main/resources/bin/update.bat
@@ -1,0 +1,24 @@
+@ECHO off
+SETLOCAL
+
+IF [%~1]==[] GOTO printArgs
+IF NOT [%~2]==[] IF NOT "%~2"=="true" IF NOT "%~2"=="false" GOTO printArgs
+
+SET snapshot=False
+if "%~2"=="true" SET snapshot=True
+
+powershell -command "& { . .\update.ps1; Update-openHAB -OHVersion %~1 -Snapshot $%snapshot% }"
+EXIT /B 0
+
+:printArgs
+ECHO Usage: update.bat {OHVersion} [{Snapshot}]
+ECHO OHVersion (required) - The version you want to update (2.3, 2.4, etc)
+ECHO Snapshot  (optional) - "true" if snapshot, "false" or not specified for stable
+ECHO.
+ECHO Example to update to OH version 2.3 stable:
+ECHO    update.bat 2.3
+ECHO.
+ECHO Example to update to OH version 2.3 snapshot:
+ECHO    update.bat 2.3 true
+ECHO.
+EXIT /B -1

--- a/distributions/openhab/src/main/resources/bin/update.ps1
+++ b/distributions/openhab/src/main/resources/bin/update.ps1
@@ -10,6 +10,9 @@ Set-StrictMode -Version Latest
     The directory where openHAB is installed (default: current directory).
     .PARAMETER OHVersion
     The version to upgrade to.
+    .PARAMETER Snapshot
+    DEPRECATED - Upgrade to a snapshot version ($true) or a release version ($false) (default: $false)
+    DEPRECATED - Please specify "-snapshot" in the OHVersion instead (ex: "2.4.0-SNAPSHOT")
     .PARAMETER AutoConfirm
     Automatically confirm update (used for headless mode)
     .EXAMPLE
@@ -27,6 +30,8 @@ Function Update-openHAB() {
         [string]$OHDirectory = ".",
         [Parameter(ValueFromPipeline = $True)]
         [string]$OHVersion,
+        [Parameter(ValueFromPipeline = $True)]
+        [boolean]$Snapshot = $false,
         [Parameter(ValueFromPipeline = $True)]
         [boolean]$AutoConfirm = $false,
         [Parameter(ValueFromPipeline = $True)]
@@ -298,8 +303,10 @@ Function Update-openHAB() {
     BoxMessage "openHAB 2.x.x update script" Magenta
     Write-Host ""
     
-    # Check for admin/openhab running
-    CheckForAdmin
+    # Check for admin (commented out - don't think we need it)
+    # CheckForAdmin
+
+    # Check for openhab running
     CheckOpenHABRunning
 
     # Check if service is installed, stop and delete it
@@ -363,7 +370,7 @@ Function Update-openHAB() {
 
     # Determine if it's a snapshot
     $CurrentVersionSnapshot = $False;
-    if ($CurrentVersion.EndsWith("-SNAPSHOT")) {
+    if ($CurrentVersion.EndsWith("-SNAPSHOT", "CurrentCultureIgnoreCase")) {
         $CurrentVersionSnapshot = $True;
         $CurrentVersion = $CurrentVersion.Substring(0, $CurrentVersion.Length - "-SNAPSHOT".Length);
     }
@@ -396,6 +403,14 @@ Function Update-openHAB() {
 
     }
 
+    # If snapshot was defined, add "-snapshot" to the OHVersion if not already present
+    if ($Snapshot -eq $true) {
+        BoxMessage "-SNAPSHOT is deprecated - please put '-snapshot' in OHVersion instead (ex: 2.4.0-snapshot)" Magenta
+        if (-Not $OHVersion.EndsWith("-SNAPSHOT", "CurrentCultureIgnoreCase")) {
+            $OHVersion = $OHVersion + "-SNAPSHOT"
+        }
+    }
+
     # Split up the OHVersion to validate
     $parts = $OHVersion.Split(".")
 
@@ -414,9 +429,9 @@ Function Update-openHAB() {
 
     $Snapshot = $False
     $Milestone = ""
-    if ($parts[2].EndsWith("-SNAPSHOT")) {
+    if ($parts[2].EndsWith("-SNAPSHOT", "CurrentCultureIgnoreCase")) {
         $Snapshot = $True
-        $parts[2] = $parts[2].Substring(0, $parts[2].IndexOf("-SNAPSHOT"))
+        $parts[2] = $parts[2].Substring(0, $parts[2].Length - "-SNAPSHOT".Length);
     } elseif ($parts.Length -eq 4) {
         $Milestone = $parts[3]
     }

--- a/distributions/openhab/src/main/resources/bin/update.ps1
+++ b/distributions/openhab/src/main/resources/bin/update.ps1
@@ -363,17 +363,9 @@ Function Update-openHAB() {
 
     # Determine if it's a snapshot
     $CurrentVersionSnapshot = $False;
-    $CurrentVersionMilestone = ""
     if ($CurrentVersion.EndsWith("-SNAPSHOT")) {
         $CurrentVersionSnapshot = $True;
         $CurrentVersion = $CurrentVersion.Substring(0, $CurrentVersion.Length - "-SNAPSHOT".Length);
-    } else {
-        # Split up the current version to validate
-        $parts = $CurrentVersion.Split(".")
-        if ($parts.Length -eq 4) {
-            $CurrentVersionMilestone = $parts[3]
-            $CurrentVersion = $parts[0] + "." + $parts[1] + "." + $parts[2]`
-        }
     }
 
     # Tell the user our current version
@@ -556,7 +548,7 @@ Function Update-openHAB() {
                 # go back to our original directory so the new update script does it as well
                 Set-Location -Path $StartDir  -ErrorAction Continue 
                 . $newUpdate
-                exit Update-openHAB -OHDirectory $OHDirectory -OHVersion $OHVersion -Snapshot $Snapshot -AutoConfirm $AutoConfirm -SkipNew $true -KeepUpdateScript $KeepUpdateScript
+                exit Update-openHAB -OHDirectory $OHDirectory -OHVersion $OHVersionName -AutoConfirm $AutoConfirm -SkipNew $true -KeepUpdateScript $KeepUpdateScript
             } catch {
                 exit PrintAndReturn "Execution of new update.ps1 failed - please execute it yourself (found in $newUpdate)" $_
             }
@@ -565,8 +557,8 @@ Function Update-openHAB() {
 
     # Do the following questions after the update.ps1 check to make sure this question isn't asked twice!
 
-    # Are we resinstalling the current version (as long as it's not a snapshot or milestone)
-    if (($OHVersion -eq $CurrentVersion) -and ($Snapshot -eq $False) -and ($CurrentVersionMilestone -eq "")) {
+    # Are we resinstalling the current version (as long as it's not a snapshot)
+    if ($OHVersion -eq $CurrentVersion -and $Snapshot -eq $False) {
         if ($AutoConfirm) {
             Write-Host -ForegroundColor Magenta "Current version is equal to specified version ($OHVersionName).  ***REINSTALLING*** $OHVersionName instead (rather than upgrading)."
         } else {

--- a/distributions/openhab/src/main/resources/bin/update.ps1
+++ b/distributions/openhab/src/main/resources/bin/update.ps1
@@ -1,64 +1,7 @@
-﻿#Requires -Version 4.0
-function DownloadFiles {
-    param(
-        [Parameter(Mandatory=$true)]
-        [string]$DownloadSource,
-        [Parameter(Mandatory=$true)]
-        [string]$Outputfile,
-        [Parameter(Mandatory=$false)]
-        [string]$SkipNew
-    )
+﻿#Requires -Version 5.0
+Set-StrictMode -Version Latest
 
-    $uri = New-Object "System.Uri" "$DownloadSource"
-    $request = [System.Net.HttpWebRequest]::Create($uri)
-    $request.set_Timeout(15000)
-    $response = $request.GetResponse()
-    $totalLength = [System.Math]::Floor($response.get_ContentLength()/1024)
-    $responseStream = $response.GetResponseStream()
-    $targetStream = New-Object -TypeName System.IO.FileStream -ArgumentList $Outputfile, Create
-    $buffer = new-object byte[] 10KB
-    $count = $responseStream.Read($buffer,0,$buffer.length)
-    $downloadedBytes = $count
-    while ($count -gt 0)
-    {
-        [System.Console]::CursorLeft = 0
-        [System.Console]::Write("Downloaded {0}K of {1}K", [System.Math]::Floor($downloadedBytes/1024), $totalLength)
-        $targetStream.Write($buffer, 0, $count)
-        $count = $responseStream.Read($buffer,0,$buffer.length)
-        $downloadedBytes = $downloadedBytes + $count
-    }
-    Write-Host "`nFinished Download"
-    $targetStream.Flush()
-    $targetStream.Close()
-    $targetStream.Dispose()
-    $responseStream.Dispose()
-
-    if ($SkipNew -eq $false)
-    {
-        # Check for newer update.ps1
-        Add-Type -AssemblyName System.IO.Compression.FileSystem
-        $zip = [IO.Compression.ZipFile]::OpenRead($Outputfile)
-        $update = $zip.Entries | where {$_.FullName -like 'runtime/bin/update.ps1'}
-
-        if ($update)
-        {
-            $newUpdate = Join-Path $TempDir $update.Name
-            [IO.Compression.ZipFileExtensions]::ExtractToFile($update, $newUpdate)
-            Write-Host -ForegroundColor Red "==================================="
-            Write-Host -ForegroundColor Red "New Update.ps1 found. Using that..."
-            Write-Host -ForegroundColor Red "==================================="
-            $zip.Dispose()
-            Remove-Item $OutputFile -Force
-            . $newUpdate
-            Update-openHAB -OHDirectory $OHDirectory -OHVersion $OHVersion -Snapshot $Snapshot -SkipNew $true
-            Return 2
-        }
-        $zip.Dispose()
-    }
-}
-
-Function Update-openHAB {
-    <#
+<#
     .SYNOPSIS
     Updates openHAB to the latest version.
     .DESCRIPTION
@@ -69,6 +12,8 @@ Function Update-openHAB {
     The version to upgrade to.
     .PARAMETER Snapshot
     Upgrade to a snapshot version ($true) or a release version ($false) (default: $false)
+    .PARAMETER AutoConfirm
+    Automatically confirm update (used for headless mode)
     .PARAMETER SkipNew
     Internal use only. For skipping the check for a new update.ps1
     .EXAMPLE
@@ -76,183 +21,573 @@ Function Update-openHAB {
     Update-openHAB
     .EXAMPLE
     Update the openHAB distribution in the C:\oh-snapshot directory to the next snapshot version
-    Update-openHAB -OHDirectory C:\oh-snapshot -OHVersion 2.2.0 -Snapshot $true
-    #>
+    Update-openHAB -OHDirectory C:\oh-snapshot -OHVersion 2.3.0 -Snapshot $true
+#>
 
+Function Update-openHAB() {
     [CmdletBinding()]
     param(
-        [Parameter(ValueFromPipeline=$True)]
+        [Parameter(ValueFromPipeline = $True)]
         [string]$OHDirectory = ".",
-        [Parameter(ValueFromPipeline=$True)]
-        [string]$OHVersion = "2.1.0",
-        [Parameter(ValueFromPipeline=$True)]
+        [Parameter(ValueFromPipeline = $True)]
+        [string]$OHVersion,
+        [Parameter(ValueFromPipeline = $True)]
         [boolean]$Snapshot = $false,
-        [Parameter(ValueFromPipeline=$True)]
-        [boolean]$SkipNew = $false
+        [Parameter(ValueFromPipeline = $True)]
+        [boolean]$AutoConfirm = $false,
+        [Parameter(ValueFromPipeline = $True)]
+        [boolean]$SkipNew = $false,
+        [Parameter(ValueFromPipeline = $True)]
+        [boolean]$KeepUpdateScript = $false  # sssh - secret switch ;)
     )
 
-    begin {}
-    process {
+    function DownloadFiles() {
+        param(    
+            [Parameter(Mandatory = $True)]
+            [string] $DownloadSource, 
+            [Parameter(Mandatory = $True)]
+            [string] $OutputFile
+        ) 
+    
+        $uri = New-Object "System.Uri" "$DownloadSource"
 
-        if (!([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
-            ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-            throw "This script must be run as an Administrator. Start PowerShell with the Run as Administrator option"
+        $request = [System.Net.HttpWebRequest]::Create($uri)
+        $request.set_Timeout(15000)
+
+        Invoke-WebRequest $uri -Outfile $Outputfile -ErrorAction Stop
+    }
+
+    function NormalizeVersionNumber() {
+        param(    
+            [Parameter(Mandatory = $True)]
+            [string] $VersionNumber
+        )
+
+        $parts = $VersionNumber.Split(".")
+        if ($parts.Length -ne 3) {
+            throw "$VersionNumber is not formatted correctly (d.d.d)"
         }
 
-        # Verify we're in an openHAB directory
-        Write-Host -ForegroundColor Cyan "Checking the specified openHAB directory..."
-        if (!(Test-Path "$OHDirectory\userdata") -And !(Test-Path -Path "$OHDirectory\conf")) {
-            throw "$OHDirectory\userdata doesn't exist! Make sure you are in the " +
-                "openHAB directory or specify the -OHDirectory parameter!"
+        $rc = "";
+        $parts | ForEach-Object {
+            $rc += $_.PadLeft(5 - $_.Length, '0')
+            $rc += "."
+        }
+        return $rc.Substring(0, $rc.Length - 1)
+    }
+
+    function ProcessCommand() {
+        param(    
+            [Parameter(Mandatory = $True)]
+            [string] $Line
+        )
+
+        $parts = $Line.Split(";")
+
+        # blank line - simply return
+        if ($parts.length -eq 0) {
+            return;
         }
 
-
-        # Get current openHAB version
-        if (Test-Path "$OHDirectory\userdata\etc\version.properties")
-        {
-            $VersionLine = Get-Content "$OHDirectory\userdata\etc\version.properties" | Where-Object { $_.Contains("openhab-distro")}
-            $CurrentVersionIndex = $VersionLine.IndexOf(":")
-            $CurrentVersion = $VersionLine.Substring($currentVersionIndex + 2)
-            if ($OHVersion -eq $CurrentVersion) {
-                throw "You are already on openHAB $OHVersion"
+        if ($parts[0] -eq "DEFAULT") {
+            if ($parts.length -le 1) {
+                Write-Host -ForegroundColor Red "Badly formatted: $Line"
+            }
+            else {
+                try {
+                    Rename-Item -Path $parts[1] "$parts[1].bak" -ErrorAction Stop
+                    Write-Host -ForegroundColor Cyan "$($parts[1]) renamed to $($parts[1]).bak"
+                }
+                catch {
+                    Write-Host -ForegroundColor Yellow "Could not rename $($parts[1]) to $($parts[1]).bak"
+                }
             }
         }
+        ElseIf ($parts[0] -eq "DELETEDIR" -or $parts[0] -eq "DELETE") {
+            if ($parts.length -le 1) {
+                Write-Host -ForegroundColor Red "Badly formatted: $Line"
+            }
+            else {
+                try {
+                    DeleteIfExists $parts[1]
+                    Write-Host -ForegroundColor Cyan "Deleted $($parts[1])"
+                }
+                catch {
+                    Write-Host -ForegroundColor Yellow "Could not delete $($parts[1])"
+
+                }
+            }
+        }
+        ElseIf ($parts[0] -eq "MOVE") {
+            if ($parts.length -le 2) {
+                Write-Host -ForegroundColor Red "Badly formatted: $Line"
+            }
+            else {
+                try {
+                    Move-Item -Path $parts[1] -Destination $parts[2] -ErrorAction Stop
+                    Write-Host -ForegroundColor Cyan "Moved $($parts[1]) to $($parts[2])"
+                }
+                catch {
+                    Write-Host -ForegroundColor Yellow "Could not move $($parts[1]) to $($parts[2])"
+                }
+            }
+        }
+        ElseIf ($parts[0] -eq "NOTE") {
+            if ($parts.length -le 1) {
+                Write-Host -ForegroundColor Red "Badly formatted: $Line"
+            }
+            else {
+                Write-Host -ForegroundColor Green "Note: " -NoNewLine 
+                Write-Host $parts[1]
+            }
+        }
+        ElseIf ($parts[0] -eq "ALERT") {
+            if ($parts.length -le 1) {
+                Write-Host -ForegroundColor Red "Badly formatted: $Line"
+            }
+            else {
+                Write-Host -ForegroundColor Red "Warning: " -NoNewLine 
+                Write-Host $parts[1]
+            }
+        }
+        Else {
+            Write-Host -ForegroundColor Red "Unknown command: $Line"
+        }
+    }
+
+    function ProcessVersionChange() {
+        param(
+            [Parameter(Mandatory = $True)]
+            [string] $FileName,
+            [Parameter(Mandatory = $True)]
+            [string] $Section,
+            [Parameter(Mandatory = $True)]
+            [string] $VersionMsg,
+            [Parameter(Mandatory = $True)]
+            [string] $CurrentVersion
+        )
+
+        $InSection = $false
+        $InNewVersion = $false
+
+        $NormalizedCurrentVersion = NormalizeVersionNumber $CurrentVersion
+        Get-Content $FileName -ErrorAction Stop | ForEach-Object {
+            if ($_ -ne "") {
+                if ($_ -match "\[\[$Section\]\]") {
+                    $InSection = $True
+                }
+                ElseIf ($_ -match "\[\[.*\]\]") {
+                    $InSection = $false
+                    $InNewVersion = $false
+                }
+                ElseIf ($_ -match "\[\d\.*\d\.*\d\]") {
+                    if ($InSection) {
+                        $NormalizedVersion = NormalizeVersionNumber $_.Substring(1, $_.length - 2)
+                        $InNewVersion = ($NormalizedCurrentVersion -lt $NormalizedVersion)
+                        if ($InNewVersion -and $InSection) {
+                            Write-Host ""
+                            Write-Host -ForegroundColor Cyan "$VersionMsg $_ :"
+                        }
+                    }
+                }
+                else {
+                    if ($InSection -and $InNewVersion) {
+                        ProcessCommand $_
+                    }
+                }
+            }
+        }
+    }
+
+    Import-Module $PSScriptRoot\common.psm1 -Force
+
+    Write-Host ""
+    BoxMessage "openHAB 2.x.x update script" Magenta
+    Write-Host ""
+    
+    try {
+        $StartDir = Get-Location -ErrorAction Stop 
+    }
+    catch {
+        return PrintAndReturn "Can't retrieve the current location - exiting" $_
+    }
+
+    CheckForAdmin
+    CheckOpenHABRunning
 
 
-        # Check if service is installed, stop and delete it
-        Write-Host -ForegroundColor Cyan "Checking whether a service exists..."
-        $service = (Get-WmiObject Win32_Service -filter "name LIKE 'openHAB%'")
+    # Find the proper directory
+    Write-Host -ForegroundColor Cyan "Checking the specified openHAB directory"
+    $OHDirectory = GetOpenHABRoot $OHDirectory
+    if ($OHDirectory -eq "") {
+        return PrintAndReturn "Could not find the openHAB directory! Make sure you are in the openHAB directory or specify the -OHDirectory parameter!"
+    }
+
+    # Get current openHAB version
+    $CurrentVersion = GetOpenHABVersion $OHDirectory;
+    if ($CurrentVersion -eq "") {
+        return PrintAndReturn "Can't get the current openhab version from $OHDirectory - exiting"
+    }
+    if ($CurrentVersion.EndsWith("-SNAPSHOT")) {
+        $CurrentVersion = $CurrentVersion.Substring(0, $CurrentVersion.Length - "-SNAPSHOT".Length);
+    }
+
+    if (-Not $OHVersion) {
+        # If snapshot - just used the current version
+        # If not - bump minor of current version by 1
+        if ($Snapshot) {
+            $OHVersion = $CurrentVersion
+        }
+        else {
+            $parts = $CurrentVersion.Split(".")
+            if ($parts.Length -eq 3) {
+                $OHVersion = $parts[0] + "." + ([int]$parts[1] + 1) + "." + $parts[2]
+            }
+            else {
+                return PrintAndReturn "The current version $CurrentVersion was not formatted correctly (d.d.d)"
+            }
+        }
+    }
+
+    # Check if service is installed, stop and delete it
+    Write-Host -ForegroundColor Cyan "Checking whether a service exists"
+    try {
+        $service = Get-Service 'openHAB%' -ErrorAction Ignore
         if ($service) {
             # Stop and delete the service
-            Write-Host -ForegroundColor Cyan "Stopping the service..."
-            Stop-Service $service.Name -Force
-            Write-Host -ForegroundColor Cyan "Deleting the service..."
-            $service.Delete()
+            Write-Host -ForegroundColor Cyan "Stopping the service"
+            Stop-Service $service.Name -Force -ErrorAction Stop
+            Write-Host -ForegroundColor Cyan "Deleting the service"
+            Remove-Service $service.Name -ErrorAction Stop
+        }
+    }
+    catch {
+        return PrintAndReturn "Could not stop/delete the openHAB windows server - please do that manually and try again" $_
+    }
+
+    Write-Host -ForegroundColor Cyan "Changing location to $OHDirectory"
+    try {
+        Set-Location -Path $OHDirectory
+    }
+    catch {
+        return PrintAndReturn "Could not change location to $OHDirectory - exiting" $_
+    }
+
+    # Download the selected openHAB version
+    # Choose bintray for releases, jenkins for snapshots.
+    $TempDir = "$(GetOpenHABTempDirectory)\update"
+    $OutputFile = "$TempDir\openhab-$OHVersion.zip"
+    $TempDistributionZip = "$TempDir\openhab-$OHVersion.zip";
+    $TempDistribution = "$TempDir\openhab-$OHVersion"
+    if ($Snapshot) {
+        $OHVersion = "$OHVersion-SNAPSHOT"
+        $DownloadLocation="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-$OHVersion.zip"
+        $AddonsDownloadLocation="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-$OHVersion.kar"
+        $LegacyAddonsDownloadLocation="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-$OHVersion.kar"
+    }
+    else {
+        $DownloadLocation = "https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F$OHVersion%2Fopenhab-$OHVersion.zip"
+        $AddonsDownloadLocation = "https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F$OHVersion%2Fopenhab-addons-$OHVersion.kar"
+        $LegacyAddonsDownloadLocation = "https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F$OHVersion%2Fopenhab-addons-legacy-$OHVersion.kar"
+    }
+
+    if ($Snapshot) {
+        Write-Host -ForegroundColor Yellow "The current version is $CurrentVersion-SNAPSHOT"
+    } else {
+        Write-Host -ForegroundColor Yellow "The current version is $CurrentVersion"        
+    }
+    Write-Host -ForegroundColor Yellow "Upgrading to version $OHVersion"
+
+    # If we are not in SkipNew:
+    #   1. (Re)Create the temporary distribution directory
+    #   2. Download the distribution to the temp directory
+    #   3. Expand the distribution to the temp directory
+    #   4. Detect whether a new update.ps1 should be executed
+    # If we are in skipnew - all this should have been done already
+    if ($SkipNew -eq $False) {
+        ########### STEP 1 - create the temporary distribution directory
+        try {
+            DeleteIfExists $TempDir
+        }
+        catch {
+            # Do nothing here - probably a file lock issue
         }
 
-
-        # Checking if openHAB is running
-        Write-Host -ForegroundColor Cyan "Checking whether openHAB is running..."
-        $m = (Get-WmiObject Win32_Process -Filter "name = 'java.exe'" |
-              where { $_.CommandLine.Contains("openhab") } | measure)
-        if ($m.Count -gt 0) {
-            throw "openHAB seems to be running, stop it before running this update script"
+        try {
+            Write-Host -ForegroundColor Cyan "Creating temporary update directory $TempDir"
+            CreateDirectory $TempDir
+        }
+        catch {
+            return PrintAndReturn "Error creating temporary update directory $TempDir - exiting" $_
         }
 
+        ########### STEP 2 - download the distribution
+        try {
+            Write-Host -ForegroundColor Cyan "Downloading the openHAB $OHVersion distribution to $TempDistributionZip"
+            DownloadFiles $DownloadLocation $TempDistributionZip
+        }
+        catch {
+            return PrintAndReturn "Download of $DownloadLocation failed" $_
+        }
 
-        # Backup openHAB only if not coming via new update script
-        if ($SkipNew -eq $false)
-        {
+        ########### STEP 3 - Expand the archive
+        try {
+            Write-Host -ForegroundColor Cyan "Extracting the archive ($TempDistributionZip) to $TempDistribution"
+            Expand-Archive -Path $TempDistributionZip -DestinationPath $TempDistribution -Force -ErrorAction Stop
+        } catch {
+            return PrintAndReturn "Unzipping of $TempDistributionZip to $TempDistribution failed." $_
+        }
+
+        ########### STEP 4 - Run new update.ps1 if needed
+        $newUpdate = Join-Path $TempDistribution "/runtime/bin/update.ps1"
+        if ($KeepUpdateScript) {
+            try {
+                Copy-Item -Path "$OHDirectory/runtime/bin/common.psm1" -Destination "$TempDistribution/runtime/bin/common.psm1" -Force
+                Copy-Item -Path "$OHDirectory/runtime/bin/update.ps1" -Destination $newUpdate -Force
+            } catch {
+                Write-Host -ForegroundColor Magenta "Could not copy the update.ps1 to the new distribution"
+                # Don't bother with AutoConfirm here since this is special debugging logic to begin with
+                $confirmation = Read-Host "Okay to Continue? [y/N]"
+                if ($confirmation -ne 'y') {
+                    return PrintAndReturn "Cancelling update"
+                }
+            }
+        }
+        
+        If (Test-Path $newUpdate) {
             Write-Host ""
-            Write-Host -ForegroundColor Magenta "Backup script starting..."
-            Write-Host -ForegroundColor Cyan "Making a backup in '$OHDirectory\backups' ..."
-            $BackupScript = Join-Path (pwd) '\runtime\bin\backup.ps1'
-            . $BackupScript
-            Backup-openHAB -OHDirectory (pwd)
-            Write-Host -ForegroundColor Magenta "Backup script finished."
+            BoxMessage "New update.ps1 was found - executing it instead (found in $newUpdate)" Magenta
             Write-Host ""
+            try {
+                $rawOHVersion = $OHVersion
+                if ($rawOHVersion.EndsWith("-SNAPSHOT")) {
+                    $rawOHVersion = $rawOHVersion.Substring(0, $rawOHVersion.Length - "-SNAPSHOT".Length)
+                }
+                # go back to our original directory so the new update script does it as well
+                Set-Location -Path $StartDir  -ErrorAction Continue 
+                . $newUpdate
+                Update-openHAB -OHDirectory $OHDirectory -OHVersion $rawOHVersion -Snapshot $Snapshot -AutoConfirm $AutoConfirm -SkipNew $true -KeepUpdateScript $KeepUpdateScript
+                return 2;
+            } catch {
+                return PrintAndReturn "Execution of new update.ps1 failed - please execute it yourself (found in $newUpdate)" $_
+            }
+        }
+    }
+
+    # Backup openHAB only if not coming via new update script
+    $BackupFile = "$OHDirectory\backup-$CurrentVersion.zip"
+    Write-Host ""
+    Write-Host -ForegroundColor Cyan "Making a backup of your distribution to $BackupFile"
+    try {
+        DeleteIfExists $BackupFile
+        Compress-Archive -Path "$OHDirectory\*" -DestinationPath $BackupFile -CompressionLevel Fastest -ErrorAction Stop
+    } catch {
+        return PrintAndReturn "Could not backup existing distribution to $BackupFile" $_
+    }
+    
+    try {
+        $updateLst = Join-Path $TempDistribution "/runtime/bin/update.lst"
+
+        if (Test-Path $updateLst) {
+            Write-Host ""
+            Write-Host -ForegroundColor Cyan "The script will attempt to update openHAB to version $OHVersion"
+            Write-Host -ForegroundColor Cyan "Please read the following " -NoNewLine
+            Write-Host -ForegroundColor Green "notes" -NoNewLine
+            Write-Host -ForegroundColor Cyan " and " -NoNewLine
+            Write-Host -ForegroundColor Red "warnings"
+            try {
+                ProcessVersionChange $updateLst "MSG" "Important notes for version" $CurrentVersion
+            } catch {
+                # PrintAndReturn since there have been no file changes yet
+                return PrintAndReturn "Could not process 'MSG' of $updateLst" $_
+            }
+
+            if (-Not $AutoConfirm) {
+                $confirmation = Read-Host "Okay to Continue? [y/N]"
+                if ($confirmation -ne 'y') {
+                    return PrintAndReturn "Cancelling update"
+                }
+            }
         }
 
-
-        # Set the temporary directories
-        $TempDir=([Environment]::GetEnvironmentVariable("TEMP", "Machine"))+"\openhab"
-        $OutputFile = "$TempDir\openhab-$OHVersion.zip"
-        if (Test-Path $TempDir)
-        {
-            Remove-Item $TempDir -Recurse
+        try {
+            Write-Host ""
+            Write-Host -ForegroundColor Cyan "Execute 'PRE' instructions"
+            ProcessVersionChange $updateLst "PRE" "Performing pre-update tasks for version" $CurrentVersion
+        } catch {
+            return PrintAndThrow "Could not process 'PRE' of $updateLst" $_
         }
-        New-Item $TempDir -Type directory -Force | Out-Null
-
-
-        # Download the selected openHAB version
-        # Choose bintray for releases, jenkins for snapshots.
-        if ($Snapshot) {
-            if(!$OHVersion.EndsWith("-SNAPSHOT")){ $OHVersion = "$OHVersion-SNAPSHOT" }
-            $DownloadLocation="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-$OHVersion.zip"
-            $AddonsDownloadLocation="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-$OHVersion.kar"
-            $LegacyAddonsDownloadLocation="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-$OHVersion.kar"
-            Write-Host -ForegroundColor Cyan "Downloading the openHAB $OHVersion distribution..."
-            $DL = DownloadFiles $DownloadLocation "$TempDir\openhab-$OHVersion.zip" $SkipNew
-            if ($DL -eq 2) {Return}
-        } else {
-            $DownloadLocation="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F$OHVersion%2Fopenhab-$OHVersion.zip"
-            $AddonsDownloadLocation="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F$OHVersion%2Fopenhab-addons-$OHVersion.kar"
-            $LegacyAddonsDownloadLocation="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F$OHVersion%2Fopenhab-addons-legacy-$OHVersion.kar"
-            Write-Host -ForegroundColor Cyan "Downloading the openHAB $OHVersion distribution..."
-            $DL = DownloadFiles $DownloadLocation "$TempDir\openhab-$OHVersion.zip" $SkipNew
-            if ($DL -eq 2) {Return}
-        }
-
-
-        # Unzip new files
-        Write-Host -ForegroundColor Cyan "Extracting the archive to $TempDir\openhab-$OHVersion..."
-        Add-Type -AssemblyName System.IO.Compression.FileSystem
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("$TempDir\openhab-$OHVersion.zip", "$TempDir\openhab-$OHVersion")
-
+        Write-Host ""
 
         # Delete current userdata files
-        Write-Host -ForegroundColor Cyan "Deleting current files in userdata that should not persist..."
-        foreach($FileName in Get-Content "$TempDir\openhab-$OHVersion\runtime\bin\userdata_sysfiles.lst"){
-            Remove-Item "$OHDirectory\userdata\etc\$FileName" -ErrorAction SilentlyContinue
-        }
-        Remove-Item ($OHDirectory + '\userdata\cache') -Recurse -ErrorAction SilentlyContinue
-        Remove-Item ($OHDirectory + '\userdata\tmp') -Recurse -ErrorAction SilentlyContinue
-
-        ## Removing files that must not exist anymore in an installation.
-        Remove-Item ($OHDirectory + '\userdata\etc\org.openhab.addons.cfg') -ErrorAction SilentlyContinue
-
-        # Keep a backup of this file in case the user modified it
-        Copy-Item ($OHDirectory + '\userdata\etc\org.ops4j.pax.logging.cfg') ($OHDirectory + '\userdata\etc\org.ops4j.pax.logging.cfg.bak')
-
-
         # Update openHAB
-        Write-Host -ForegroundColor Cyan "Deleting current runtime..."
-        Remove-Item ($OHDirectory + '\runtime') -Recurse -ErrorAction SilentlyContinue
+        #   1. First remove all file in runtime (they will all be replaced)
+        #   2. Remove all the userdata\etc files listed in userdata_sysfiles.lst (they will be replaced)
+        #   3. Remove the cache/tmp directories
+        #   4. Then copy all files from our new distribution WITHOUT overwriting anything
+        #      (by removals in 1 & 2 - that means we will replace those)
+        #
 
-        Write-Host -ForegroundColor Cyan "Copying new runtime..."
-        Copy-Item $TempDir\openhab-$OHVersion\runtime -Destination $OHDirectory\runtime -Force -Recurse
+        ############## STEP 1 - remove runtime
+        $runtime = Join-Path $OHDirectory "\runtime"
+        try {
+            Write-Host -ForegroundColor Cyan "Deleting current runtime ($runtime)"
+            DeleteIfExists $runtime
+        } catch {
+            return PrintAndThrow "Could not delete current runtime ($runtime)" $_
+        }
 
-        Write-Host -ForegroundColor Cyan "Copying userdata files to new install without overwriting existing ones..."
-        $newuserdata = Get-Item $TempDir\openhab-$OHVersion\userdata
-        Get-ChildItem -Path $newuserdata -Recurse | Copy-Item -Destination {
-            if ($_.PSIsContainer) {
-                $path = Join-Path "$OHDirectory\userdata" $_.Parent.FullName.Substring($newuserdata.FullName.Length)
-                #Write-Host $path
-                $path
-            } else {
-                $path = Join-Path "$OHDirectory\userdata" $_.FullName.Substring($newuserdata.FullName.Length)
-                #Write-Host $path
-                $path
+        ############## STEP 2 - remove userdata\etc files in userdata_sysfiles.lst
+        Write-Host -ForegroundColor Cyan "Deleting current files in userdata that should not persist"
+        foreach ($FileName in Get-Content "$TempDistribution\runtime\bin\userdata_sysfiles.lst") {
+            $fileToDelete = "$OHDirectory\userdata\etc\$FileName"
+            try {
+                if (Test-Path -Path $fileToDelete) {
+                    DeleteIfExists $fileToDelete
+                    Write-Host -ForegroundColor Cyan "Deleted $FileName from $OHDirectory\userdata\etc"
+                }
+            } catch {
+                Write-Error $_
+                Write-Host "Could not delete $fileToDelete.  File is no longer needed and should be manually deleted."
             }
-        } -ErrorAction SilentlyContinue | Out-Null
+        }
+
+        ############## STEP 3 - remove cache/tmp directories
+        try {
+            Write-Host -ForegroundColor Cyan "Removing $OHDirectory\userdata\cache"
+            DeleteIfExists "$OHDirectory\userdata\cache"
+        } catch {
+            return PrintAndThrow "Could not delete the $OHDirectory\userdata\cache directory" $_
+        }
+
+        try {
+            Write-Host -ForegroundColor Cyan "Removing $OHDirectory\userdata\tmp"
+            DeleteIfExists "$OHDirectory\userdata\tmp"
+        } catch {
+            return PrintAndThrow "Could not delete the $OHDirectory\userdata\tmp directory" $_
+        }
+
+        ############## STEP 4 - copy files from temporary to distribution WITHOUT replacement
+        Write-Host -ForegroundColor Cyan "Copying $TempDistribution to $OHDirectory without overwriting existing ones"
+        try {
+            Get-ChildItem -Path $TempDistribution -Recurse -ErrorAction Stop | ForEach-Object { 
+                $relPath = GetRelativePath $TempDistribution $_.FullName
+                $localPath = Join-Path $OHDirectory $relPath
+                if (-Not (Test-Path $localPath)) {
+                    if (Test-Path $localPath -PathType Container) {
+                        CreateDirectory $localPath
+                    } else {
+                        Copy-Item -Path $_.FullName -Destination $localPath -ErrorAction Stop
+                    }
+                }
+            }
+        } catch {
+            return PrintAndThrow "Error occurred copying $TempDistribution to $OHDirectory" $_
+        }
+
+        Write-Host ""
+        try {
+            Write-Host -ForegroundColor Cyan "Execute 'POST' instructions"
+            ProcessVersionChange $updateLst "POST" "Performing post-update tasks for version" $CurrentVersion
+        } catch {
+            return PrintAndThrow "Could not process 'POST' of $updateLst" $_
+        }
+        Write-Host ""
 
 
         # If there's an existing addons file, we need to replace it with the correct version.
-        $AddonsFile="$OHDirectory\addons\openhab-addons-$CurrentVersion.kar"
-        if (Test-Path -Path $AddonsFile) {
-            Write-Host "Found an openHAB addons file, replacing with new version..."
-            Remove-Item $AddonsFile
-            DownloadFiles $AddonsDownloadLocation "$OHDirectory\addons\openhab-addons-$OHVersion.kar"
+        try {
+            $AddonsFile = "$OHDirectory\addons\openhab-addons-$OHVersion.kar"
+            if (Test-Path -Path $AddonsFile) {
+                Write-Host "Found an openHAB addons file, replacing with new version"
+                DeleteIfExists $AddonsFile
+                DownloadFiles $AddonsDownloadLocation "$OHDirectory\addons\openhab-addons-$OHVersion.kar"
+            }
+        } catch {
+            return PrintAndThrow "Could not replace the $AddonsFile" $_
         }
 
 
         # Do the same for the legacy addons file.
-        $LegacyAddonsFile="$OHDirectory\addons\openhab-addons-legacy-$CurrentVersion.kar"
-        if (Test-Path -Path $LegacyAddonsFile) {
-            Write-Host "Found an openHAB legacy addons file, replacing with new version..."
-            Remove-Item $LegacyAddonsFile
-            DownloadFiles $LegacyAddonsDownloadLocation "$OHDirectory\addons\openhab-addons-legacy-$OHVersion.kar"
+        try {
+            $LegacyAddonsFile = "$OHDirectory\addons\openhab-addons-legacy-$OHVersion.kar"
+            if (Test-Path -Path $LegacyAddonsFile) {
+                Write-Host "Found an openHAB legacy addons file, replacing with new version"
+                DeleteIfExists $LegacyAddonsFile
+                DownloadFiles $LegacyAddonsDownloadLocation "$OHDirectory\addons\openhab-addons-legacy-$OHVersion.kar"
+            }
+        } catch {
+            return PrintAndThrow "Could not replace the $LegacyAddonsFile" $_
         }
-
-
-        # Delete Temp Directory
-        Write-Host -ForegroundColor Cyan "Removing the extracted files..."
-        Remove-Item $TempDir -Recurse -ErrorAction SilentlyContinue
 
         Write-Host -ForegroundColor Green "openHAB updated to version $OHVersion!"
         Write-Host -ForegroundColor Green "Run start.bat to launch it."
         Write-Host -ForegroundColor Green "Check https://www.openhab.org/docs/installation/windows.html"
         Write-Host -ForegroundColor Green "for instructions on re-installing the Windows Service if desired"
     }
+    catch {
+        BoxMessage "Restoring your distribution from $BackupFile" Yellow
+        try {
+            Write-Host -ForegroundColor Cyan "Removing all files from distribution (except $BackupFile)"
+            Get-ChildItem -Path $OHDirectory -Recurse -ErrorAction Stop | Where-Object FullName -ne $BackupFile | ForEach-Object {
+                try {
+                    DeleteIfExists $_.FullName
+                } catch {
+                    # do nothing
+                }
+            }
 
+            Write-Host -ForegroundColor Cyan "Restoring distribution backup $BackupFile"
+            Expand-Archive -Path $BackupFile -DestinationPath $OHDirectory -Force -ErrorAction Stop
+        } catch {
+            Write-Host -ForegroundColor Cyan "Restoration was unsuccessful - you may want to try unzipping $BackupFile"
+            Write-Error $_
+
+            # Important to reset this variable so the 'finally' block doesn't delete it
+            $BackupFile = "doesntexist"
+        }
+    }
+    finally {
+        $parent = (Get-Item $TempDir).Parent.FullName
+
+        try {
+            Write-Host -ForegroundColor Cyan "Removing temporary directory $TempDir"
+            DeleteIfExists $TempDir
+        }
+        catch {
+            Write-Host -ForegroundColor Red "Could not delete $TempDir - delete it manually"
+        }
+
+        try {
+            if (-Not (Test-Path "$parent\*")) {
+                Write-Host -ForegroundColor Cyan "Removing temporary directory $parent"
+                DeleteIfExists $parent
+            }
+        }
+        catch {
+            Write-Host -ForegroundColor Red "Could not delete $parent - delete it manually"
+        }
+
+        try {
+            if (Test-Path $BackupFile) {
+                if ($AutoConfirm) {
+                    Write-Host -ForegroundColor Cyan "Removing temporary distribution backup $BackupFile"
+                    DeleteIfExists $BackupFile
+                } else {
+                    Write-Host -ForegroundColor Cyan "Your prior distribution is in $BackupFile"
+                    $confirmation = Read-Host "Should it be deleted? [y/N]"
+                    if ($confirmation -eq 'y') {
+                        Write-Host -ForegroundColor Cyan "Removing temporary distribution backup $BackupFile"
+                        DeleteIfExists $BackupFile
+                    }
+                }
+            }
+        }
+        catch {
+            Write-Host -ForegroundColor Red "Could not delete $BackupFile - delete it manually"
+        }
+
+        Write-Host -ForegroundColor Cyan "Setting location back to $StartDir"
+        Set-Location -Path $StartDir  -ErrorAction Continue
+    }
 }


### PR DESCRIPTION
New PR with the following changes:
1. Implemented common.psm1 for common modules between all the powershell scripts
2. Added .bat scripts to ease running of powershell
3. Updated backup.ps1 to be compatible with the linux version
4. Created a restore.ps1 (wasn't implemented yet) - made compatible with linux version
5. Rewrote update.ps1 to fix a few bugs, add error handling and added 'stuff' from linux version (update.lst, etc)

Signed-off-by: Tim Roberts <troberts@bigfoot.com>