### PR TITLE
Update pom.xml to show Milestone Build #

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
                 </property>
             </activation>
             <properties>
-                <build.number>Milestone Build</build.number>
+                <build.number>Milestone Build 6</build.number>
                 <online.repo>https://openhab.jfrog.io/openhab/online-repo-milestone/${online.repo.version}</online.repo>
                 <pax.url.suffix/>
             </properties>


### PR DESCRIPTION
Closes: https://github.com/openhab/openhab-distro/issues/812

I am not familiar with the proper way to introduce the build number

I don't know if it is correct to hard code the number at the proposed location or it's better to create `<properties>`
like: `        <oh2m.version>6</oh2.version>`

 and then use this as a "variable"? in the:
`<build.number>Milestone Build `oh2m.version`</build.number>`

??? help is needed since I am still learning this stuff :)

Signed-off-by: Angelos Fountoulakis agf@wired-net.gr (github: AngelosF)
(not sure if signed off is needed for such minor updates)