### PR TITLE
815 Fix Startup scripts

### DIFF
--- a/distributions/openhab/src/main/resources/home/start.bat
+++ b/distributions/openhab/src/main/resources/home/start.bat
@@ -2,6 +2,13 @@
 
 echo Launching the openHAB runtime...
 
+
 setlocal
 set DIRNAME=%~dp0%
-"%DIRNAME%runtime\bin\karaf.bat" %*
+
+IF [%OPENHAB_RUNTIME%]==[] (
+	set RUNTIME=%DIRNAME%\runtime
+) ELSE (
+	set RUNTIME=%OPENHAB_RUNTIME%
+)
+"%RUNTIME%\bin\karaf.bat" %*

--- a/distributions/openhab/src/main/resources/home/start.bat
+++ b/distributions/openhab/src/main/resources/home/start.bat
@@ -2,7 +2,6 @@
 
 echo Launching the openHAB runtime...
 
-
 setlocal
 set DIRNAME=%~dp0%
 

--- a/distributions/openhab/src/main/resources/home/start.sh
+++ b/distributions/openhab/src/main/resources/home/start.sh
@@ -2,5 +2,10 @@
 
 echo Launching the openHAB runtime...
 
-DIRNAME=`dirname "$0"`
-exec "${DIRNAME}/runtime/bin/karaf" "${@}"
+if [ ! -z ${OPENHAB_RUNTIME} ]; then
+    RUNTIME=${OPENHAB_RUNTIME}
+else
+    RUNTIME="`dirname "$0"`/runtime"
+fi
+
+exec "${RUNTIME}/bin/karaf" "${@}"


### PR DESCRIPTION
Sorry @kaikreuzer - not empty anymore

The associated code fixes the start.bat/start.sh to obey OPENHAB_RUNTIME if it is defined (rather than assume the runtime is under the start script directory).

Note: I've tested this on windows and eyeballed it on linux - but we should probably have someone test that on linux