### PR TITLE
Ensure that UTF-8 is used as default for all text files on Windows

### DIFF
--- a/distributions/openhab/src/main/resources/bin/setenv.bat
+++ b/distributions/openhab/src/main/resources/bin/setenv.bat
@@ -120,7 +120,8 @@ set JAVA_OPTS=%JAVA_OPTS% ^
 
 :: set jvm options
 set EXTRA_JAVA_OPTS=-XX:+UseG1GC ^
-  -Djava.awt.headless=true
+  -Djava.awt.headless=true ^
+  -Dfile.encoding=UTF-8
 
 :: set JAVA_HOME if not set yet
 rem Setup the Java Virtual Machine


### PR DESCRIPTION
This makes sure that the behaviour on Windows is the same as on other platforms where UTF-8 is already the default encoding.

See https://github.com/eclipse/smarthome/issues/6630

Signed-off-by: Martin Herbst <develop@mherbst.de>