### PR TITLE
Use X-Forwarded-Proto for forwarded protocol as RFC7239 states

### DIFF
--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -23,7 +23,7 @@
 					<Call name="addRule">
 						<Arg>
 							<New class="org.eclipse.jetty.rewrite.handler.ForwardedSchemeHeaderRule">
-								<Set name="header">X-Forwarded-Scheme</Set>
+								<Set name="header">X-Forwarded-Proto</Set> <!-- RFC7239 states -Proto not -Scheme as header, Jetty seems to have wrong defaults -->
 								<Set name="headerValue">https</Set> <!-- if this is unset, any value will match against the rule -->
 								<Set name="scheme">https</Set>
 							</New>
@@ -32,7 +32,7 @@
 					<Call name="addRule">
 						<Arg>
 							<New class="org.eclipse.jetty.rewrite.handler.ForwardedSchemeHeaderRule">
-								<Set name="header">X-Forwarded-Scheme</Set>
+								<Set name="header">X-Forwarded-Proto</Set> <!-- RFC7239 states -Proto not -Scheme as header, Jetty seems to have wrong defaults -->
 								<Set name="headerValue">http</Set> <!-- if this is unset, any value will match against the rule -->
 								<Set name="scheme">http</Set>
 							</New>

--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -23,7 +23,7 @@
 					<Call name="addRule">
 						<Arg>
 							<New class="org.eclipse.jetty.rewrite.handler.ForwardedSchemeHeaderRule">
-								<Set name="header">X-Forwarded-Proto</Set> <!-- RFC7239 states -Proto not -Scheme as header, Jetty seems to have wrong defaults -->
+								<Set name="header">X-Forwarded-Proto</Set>
 								<Set name="headerValue">https</Set> <!-- if this is unset, any value will match against the rule -->
 								<Set name="scheme">https</Set>
 							</New>
@@ -32,7 +32,7 @@
 					<Call name="addRule">
 						<Arg>
 							<New class="org.eclipse.jetty.rewrite.handler.ForwardedSchemeHeaderRule">
-								<Set name="header">X-Forwarded-Proto</Set> <!-- RFC7239 states -Proto not -Scheme as header, Jetty seems to have wrong defaults -->
+								<Set name="header">X-Forwarded-Proto</Set>
 								<Set name="headerValue">http</Set> <!-- if this is unset, any value will match against the rule -->
 								<Set name="scheme">http</Set>
 							</New>

--- a/launch/home/etc/jetty.xml
+++ b/launch/home/etc/jetty.xml
@@ -34,7 +34,7 @@
 								<Arg>
 									<New
 										class="org.eclipse.jetty.rewrite.handler.ForwardedSchemeHeaderRule">
-										<Set name="header">X-Forwarded-Scheme</Set>
+										<Set name="header">X-Forwarded-Proto</Set> <!-- RFC7239 states -Proto not -Scheme as header, Jetty seems to have wrong defaults -->
 										<Set name="headerValue">https</Set> <!-- if this is unset, any value will match against the rule -->
 										<Set name="scheme">https</Set>
 									</New>
@@ -44,13 +44,13 @@
 								<Arg>
 									<New
 										class="org.eclipse.jetty.rewrite.handler.ForwardedSchemeHeaderRule">
-										<Set name="header">X-Forwarded-Scheme</Set>
+										<Set name="header">X-Forwarded-Proto</Set> <!-- RFC7239 states -Proto not -Scheme as header, Jetty seems to have wrong defaults -->
 										<Set name="headerValue">http</Set> <!-- if this is unset, any value will match against the rule -->
 										<Set name="scheme">http</Set>
 									</New>
 								</Arg>
 							</Call>
-							
+
 							<!-- show the dashboard as default -->
 							<Call name="addRule">
 							  <Arg>

--- a/launch/home/etc/jetty.xml
+++ b/launch/home/etc/jetty.xml
@@ -34,7 +34,7 @@
 								<Arg>
 									<New
 										class="org.eclipse.jetty.rewrite.handler.ForwardedSchemeHeaderRule">
-										<Set name="header">X-Forwarded-Proto</Set> <!-- RFC7239 states -Proto not -Scheme as header, Jetty seems to have wrong defaults -->
+										<Set name="header">X-Forwarded-Proto</Set>
 										<Set name="headerValue">https</Set> <!-- if this is unset, any value will match against the rule -->
 										<Set name="scheme">https</Set>
 									</New>
@@ -44,7 +44,7 @@
 								<Arg>
 									<New
 										class="org.eclipse.jetty.rewrite.handler.ForwardedSchemeHeaderRule">
-										<Set name="header">X-Forwarded-Proto</Set> <!-- RFC7239 states -Proto not -Scheme as header, Jetty seems to have wrong defaults -->
+										<Set name="header">X-Forwarded-Proto</Set>
 										<Set name="headerValue">http</Set> <!-- if this is unset, any value will match against the rule -->
 										<Set name="scheme">http</Set>
 									</New>


### PR DESCRIPTION
Fixes #423

In distributions/openhab/src/main/resources/runtime/etc/jetty.xml there's quite parallel configuration, just line numbers are different. Should this fix also be applied there?

(Sorry didn't know about contribution guidelines with sign-off line, so this pull request replaces #840)