### PR TITLE
added some add-ons that should be part of every package

### DIFF
--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -132,6 +132,9 @@
                         <feature>service</feature>
                         <feature>system</feature>
                         <feature>openhab-runtime-base</feature>
+                        <feature>openhab-io-javasound</feature>
+                        <feature>openhab-io-webaudio</feature>
+                        <feature>openhab-iconset-classic</feature>
                     </bootFeatures>
                     <archiveZip>false</archiveZip>
                     <archiveTarGz>false</archiveTarGz>


### PR DESCRIPTION
Re-adds the bundles that were removed with https://github.com/openhab/openhab-core/commit/45a7ce27cbbb359bbd7aba6be0a7101bb2c920f3#diff-1a67ec2e35cbc850af315533c3fec28cL45

Depends on https://github.com/openhab/openhab2-addons/pull/4657

Signed-off-by: Kai Kreuzer <kai@openhab.org>