### PR TITLE
Revert "added some add-ons that should be part of every package"

### DIFF
--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -132,9 +132,6 @@
                         <feature>service</feature>
                         <feature>system</feature>
                         <feature>openhab-runtime-base</feature>
-                        <feature>openhab-io-javasound</feature>
-                        <feature>openhab-io-webaudio</feature>
-                        <feature>openhab-iconset-classic</feature>
                     </bootFeatures>
                     <archiveZip>false</archiveZip>
                     <archiveTarGz>false</archiveTarGz>


### PR DESCRIPTION
Reverts openhab/openhab-distro#854 as it didn't do what it was supposed to.