### PR TITLE
Updated README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,13 @@ Before reporting an issue, please check the [openHAB forum](https://community.op
 
 When no solution was found, use the table below to determine where your issue should be logged:
 
-Issue | Where to report
-------|----------------
-Problems and feature requests for openHAB 1 addons | [openHAB1-addons](https://github.com/openhab/openhab1-addons/issues)
-Problems and feature requests for openHAB 2 addons | [openHAB2-addons](https://github.com/openhab/openhab2-addons/issues)
-Issues related to the runtime environment, IDE and packaging | [openHAB-distro](https://github.com/openhab/openhab-distro/issues)
-Issues related to the core openHAB bundles | [openHAB-core](https://github.com/openhab/openhab-core/issues)
+| Issue                                                        | Where to report                                                            |
+|--------------------------------------------------------------|---------------------------------------------------------------------------|
+| Problems and feature requests for openHAB 1 addons           | [openHAB1-addons](https://github.com/openhab/openhab1-addons/issues) |
+| Problems and feature requests for openHAB 2 addons           | [openHAB2-addons](https://github.com/openhab/openhab2-addons/issues) |
+| Problems and feature requests for openHAB Web UIs            | [openHAB-webui](https://github.com/openhab/openhab-webui/issues)  |
+| Issues related to the runtime environment, IDE and packaging | [openHAB-distro](https://github.com/openhab/openhab-distro/issues) |
+| Issues related to the core openHAB bundles                   | [openHAB-core](https://github.com/openhab/openhab-core/issues)   |
 
 
 But do not worry - if you are not clear, which category your issue belongs to - we will redirect you, if necessary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ Issue | Where to report
 Problems and feature requests for openHAB 1 addons | [openHAB1-addons](https://github.com/openhab/openhab1-addons/issues)
 Problems and feature requests for openHAB 2 addons | [openHAB2-addons](https://github.com/openhab/openhab2-addons/issues)
 Issues related to the runtime environment, IDE and packaging | [openHAB-distro](https://github.com/openhab/openhab-distro/issues)
-Issues related to the core openHAB bundles that are not from Eclipse SmartHome | [openHAB-core](https://github.com/openhab/openhab-core/issues)
-Issues related to Eclipse SmartHome addons and core runtime | [Eclipse SmartHome](https://github.com/eclipse/smarthome/issues)
+Issues related to the core openHAB bundles | [openHAB-core](https://github.com/openhab/openhab-core/issues)
+
 
 But do not worry - if you are not clear, which category your issue belongs to - we will redirect you, if necessary.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For further Information please refer to our homepage [www.openhab.org](http://ww
 
 ## openHAB 2 Distribution
 
-openHAB 2 is the successor of [openHAB 1](https://github.com/openhab/openhab/wiki). It is an open-source solution based on the [Eclipse SmartHome](https://www.eclipse.org/smarthome/) framework. It is fully written in Java and uses [Apache Karaf](http://karaf.apache.org/) together with [Eclipse Equinox](https://www.eclipse.org/equinox/) as an OSGi runtime and bundles this with [Jetty](https://www.eclipse.org/jetty/) as an HTTP server.
+openHAB 2 is the successor of [openHAB 1](https://github.com/openhab/openhab/wiki). It is an open-source solution. It is fully written in Java and uses [Apache Karaf](http://karaf.apache.org/) together with [Eclipse Equinox](https://www.eclipse.org/equinox/) as an OSGi runtime and bundles this with [Jetty](https://www.eclipse.org/jetty/) as an HTTP server.
 
 For the latest snapshot builds, please see to our [jenkins job](https://ci.openhab.org/job/openHAB-Distribution/).
 
@@ -25,18 +25,3 @@ If you are a developer and want to jump right into the sources and execute openH
 You can also learn [how openHAB 2 bindings are developed](https://www.openhab.org/docs/developer/development/bindings.html).
 
 In case of problems or questions, please join our vibrant [openHAB community](https://community.openhab.org/).
-
-## Acknowledgements
-
-<table>
-<tr><td width=30%><img src="https://www.digitalocean.com/assets/media/logos-badges/png/DO_Powered_by_Badge_blue-fe4c6688.png"></td>
-<td><a href="https://www.digitalocean.com">DigitalOcean</a> sponsors our <a href="https://community.openhab.org/">community forum</a> hosting.</td>
-</tr>
-<tr><td width=30%><img src="http://www.openhab.org/assets/images/bintray.png"/></td>
-<td><a href="https://www.jfrog.com">JFrog</a> is providing an <a href="https://openhab.jfrog.io">Artifactory instance for our snapshots</a> as well as distributing our <a href="https://bintray.com/openhab">releases through Bintray</a>.</td>
-</tr>
-<tr><td width=30%><img src="http://www.ej-technologies.com/images/product_banners/jprofiler_large.png"/></td>
-<td><a href="http://www.ej-technologies.com/">EJ Technologies</a> is providing us open source licenses for <a href="http://www.ej-technologies.com/products/jprofiler/overview.html">JProfiler</a> to make openHAB even more awesome.</td>
-</tr>
-
-</table>


### PR DESCRIPTION
-Removed reference to Eclipse Smart Home.
-Removed Acknowledgements section. All logo's were broken and I think the list is even incomplete. A complete list is available on the openHAB website.

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>