### PR TITLE
Update OH2 addons features dependency groupId/artifactId

### DIFF
--- a/distributions/openhab-addons/pom.xml
+++ b/distributions/openhab-addons/pom.xml
@@ -22,8 +22,8 @@
             <type>xml</type>
         </dependency>
         <dependency>
-            <groupId>org.openhab.addons</groupId>
-            <artifactId>openhab2-addons</artifactId>
+            <groupId>org.openhab.addons.features.karaf</groupId>
+            <artifactId>org.openhab.addons.features.karaf.openhab-addons</artifactId>
             <version>${oh2.version}</version>
             <classifier>features</classifier>
             <type>xml</type>


### PR DESCRIPTION
Should be merged when openhab/openhab2-addons#5018 is merged.
