### PR TITLE
Added information about channel removal in EnOcean binding

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -23,6 +23,7 @@ ALERT;senseBox Binding: The senseBox binding is now using Units of Measurements,
 ALERT;Vitotronic Binding: The following channels have been renamed: 'outsite_temp' to 'outside_temp', 'pelletburner:power' to 'pelletburner:powerlevel', 'party_temp' to 'party_temp_setpoint' and 'save_temp' to 'save_temp_setpoint'
 ALERT;OneWire Binding: Some thing types have changed and need to be updated in textual configurations. See documentation for further information.
 ALERT;REST Docs: This add-on is now part of the UIs. When installing it using textual configuration, update 'services/addons.cfg' by removing 'restdocs' from 'misc' and add it to 'ui' instead.
+ALERT:EnOcean Binding: Channel 'receivingState' has been removed, because this was a string containing many information. For this, there are three new channels: 'rssi', 'repeatCount' and 'lastReceived'.
 
 [[PRE]]
 [2.2.0]


### PR DESCRIPTION
As suggested in https://github.com/openhab/openhab2-addons/pull/4765
Signed-off-by: Dominik Vorreiter <dominikkv@gmx.de>