### PR TITLE
remove usage of ohc parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.openhab</groupId>
-        <artifactId>pom</artifactId>
-        <version>2.5.0-SNAPSHOT</version>
-        <relativePath/>
-    </parent>
-
     <groupId>org.openhab.distro</groupId>
     <artifactId>pom</artifactId>
-    <!-- do not delete the version here as it is required by the release process -->
     <version>2.5.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
@@ -48,6 +40,10 @@
     </distributionManagement>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <scm.gitBaseUrl>https://github.com/openhab</scm.gitBaseUrl>
+
         <online.repo.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</online.repo.version>        
 
         <ohc.version>2.5.0-SNAPSHOT</ohc.version>
@@ -68,6 +64,9 @@
         <dep.org.osgi.compendium.split.component.artifact>org.osgi.compendium.split.service.component</dep.org.osgi.compendium.split.component.artifact>
         <dep.org.osgi.compendium.split.event.artifact>org.osgi.compendium.split.service.event</dep.org.osgi.compendium.split.event.artifact>
         <dep.org.osgi.compendium.split.version>5.0.0</dep.org.osgi.compendium.split.version>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <modules>
@@ -92,11 +91,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${maven.compiler.plugin.version}</version>
-                    <configuration>
-                        <source>${maven.compiler.source}</source>
-                        <target>${maven.compiler.target}</target>
-                    </configuration>
+                    <version>3.6.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -104,7 +99,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>${build.helper.maven.plugin.version}</version>
+                <version>1.9.1</version>
                 <executions>
                   <execution>
                     <id>parse-version</id>
@@ -185,7 +180,7 @@
                     <plugin>
                         <groupId>org.eclipse.tycho</groupId>
                         <artifactId>tycho-versions-plugin</artifactId>
-                        <version>${tycho.version}</version>
+                        <version>1.4.0</version>
                         <executions>
                             <execution>
                                 <id>update-version</id>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,12 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.6.1</version>
                 </plugin>
-            </plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+        </plugins>
         </pluginManagement>
         <plugins>
             <plugin>


### PR DESCRIPTION
The openHAB Distro repo is the only one I know about that is still using a POM of openHAB Core "feature/p2/poms" directory (or subdirectory).

Please check if all used stuff has been moved to this POM (I have tried it but I don't know if I succeed).