### PR TITLE
Move dependency check to second unleash phase

### DIFF
--- a/launch/Jenkinsfile
+++ b/launch/Jenkinsfile
@@ -195,7 +195,6 @@ def writeUnleashWorkflows() {
     storeScmRevision
     checkProjectVersions
     checkParentVersions
-    checkDependencies
     checkPlugins
     checkPluginDependencies
     prepareVersions
@@ -210,6 +209,7 @@ def writeUnleashWorkflows() {
     def unleashPhase2Workflow = """
     prepareVersions
     checkForScmChanges
+    checkDependencies
     tagScm
     """
     


### PR DESCRIPTION
Prevents issues when `${project.version}` is used for dependency versions like e.g. here: https://github.com/openhab/openhab2-addons/blob/master/pom.xml#L80

Signed-off-by: Patrick Fink <mail@pfink.de>