### PR TITLE
fix javax.mail logger

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg
@@ -85,6 +85,10 @@ log4j2.logger.lsp4j.level = OFF
 log4j2.logger.karservice.name = org.apache.karaf.kar.internal.KarServiceImpl
 log4j2.logger.karservice.level = ERROR
 
+# Filters known issues of javax.mail, see
+# https://github.com/openhab/openhab2-addons/issues/5530
+log4j2.logger.javaxmail.name = javax.mail
+log4j2.logger.javaxmail.level = ERROR
 
 # Appenders configuration
 


### PR DESCRIPTION
javax.mail logs a WARN if `javamail.default.address.map` is not found. Unfortunately it is neither possible to put that file in a location where it can be found (in an OSGi-environment) nor to stop javax.mail to look for this file (which in fact is not needed). The suggested method is to suppress the warning by an appropriate logger configuration.

See https://github.com/openhab/openhab2-addons/issues/5530

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>