### PR TITLE
Skip tycho versions step for all projects except openhab1-addons

### DIFF
--- a/launch/Jenkinsfile
+++ b/launch/Jenkinsfile
@@ -128,7 +128,7 @@ def releaseOpenHabComponent(componentName, branch, releaseVersion, nextVersion, 
                 mvnReleaseOptions = mvnOptions + " " + mvnReleaseOptions
                 
                 stage(componentName + ": Release") {
-                    writeUnleashWorkflows()
+                    writeUnleashWorkflows(componentName == "openhab1-addons")
 
                     //Set release versions
                     if(updateProperties) {
@@ -189,8 +189,10 @@ def releaseOpenHabComponent(componentName, branch, releaseVersion, nextVersion, 
     }    
 }
 
-def writeUnleashWorkflows() {
-
+def writeUnleashWorkflows(Boolean tycho) {
+    def tychoReleaseVersionsStep = tycho ? "setReleaseVersionsTycho" : ""
+    def tychoDevVersionsStep = tycho ? "setDevVersionTycho" : ""
+    
     def unleashPhase1Workflow = """
     storeScmRevision
     checkProjectVersions
@@ -199,7 +201,7 @@ def writeUnleashWorkflows() {
     checkPluginDependencies
     prepareVersions
     #checkAether
-    setReleaseVersionsTycho
+    """ + tychoReleaseVersionsStep + """
     setReleaseVersions
     """
     
@@ -218,7 +220,7 @@ def writeUnleashWorkflows() {
     def unleashPhase3Workflow = """
     prepareVersions
     checkForScmChanges
-    setDevVersionTycho
+    """ + tychoDevVersionsStep + """
     setDevVersion
     """
     


### PR DESCRIPTION
Tycho versions step has to be skipped for all projects except openhab1-addons. Reasons:

- Tycho is not used anymore in these projects
- XML parser used by the tycho versions plugin does not parse [one of the openhab2-addons poms](https://github.com/openhab/openhab2-addons/blob/bb87c4b5d94ca5dba55cbb1a763abccfaa44d635/bom/pom.xml#L43) because of this issue: https://bitbucket.org/digulla/decentxml/issues/2/the-parser-incorrectly-flags-character-as

Signed-off-by: Patrick Fink <mail@pfink.de>