### PR TITLE
[windows] Append existing EXTRA_JAVA_OPTS

### DIFF
--- a/distributions/openhab/src/main/resources/bin/setenv.bat
+++ b/distributions/openhab/src/main/resources/bin/setenv.bat
@@ -121,7 +121,8 @@ set JAVA_OPTS=%JAVA_OPTS% ^
 :: set jvm options
 set EXTRA_JAVA_OPTS=-XX:+UseG1GC ^
   -Djava.awt.headless=true ^
-  -Dfile.encoding=UTF-8
+  -Dfile.encoding=UTF-8 ^
+  %EXTRA_JAVA_OPTS%
 
 :: set JAVA_HOME if not set yet
 rem Setup the Java Virtual Machine


### PR DESCRIPTION
This PR allows the EXTRA_JAVA_OPTS to be set in a Windows environment variable or in the start.bat, and have it appended to the end of the values set in setenv.bat. I have tested both options and also without any EXTRA_JAVA_OPTS being set. Windows users should no longer need to modify setenv.bat to set their EXTRA_JAVA_OPTS. This is especially helpful in the setup of Jython for use with scripted automation.

Fixes #920 

Signed-off-by: Scott Rushworth <openhab@5iver.com>