### PR TITLE
Upgrade Karaf to 4.2.6

### DIFF
--- a/distributions/openhab/src/main/filtered-resources/userdata/etc/org.ops4j.pax.url.mvn.cfg
+++ b/distributions/openhab/src/main/filtered-resources/userdata/etc/org.ops4j.pax.url.mvn.cfg
@@ -90,3 +90,32 @@ org.ops4j.pax.url.mvn.defaultRepositories=\
 #
 org.ops4j.pax.url.mvn.repositories= \
 	${online.repo}\@id=openhab${pax.url.suffix}
+
+#
+# Global policies override repository-specific settings (@checksum=..., @update=..., @releasesUpdate=..., ...)
+#
+#org.ops4j.pax.url.mvn.globalUpdatePolicy = daily
+#org.ops4j.pax.url.mvn.globalChecksumPolicy = warn
+
+#
+# socket and connection configuration (pax-url-aether 2.5.0)
+#
+# default value for connection and read timeouts, when socket.readTimeout and socket.connectionTimeout
+# are not specified
+org.ops4j.pax.url.mvn.timeout = 5000
+# timeout in ms when establishing http connection during artifact resolution
+org.ops4j.pax.url.mvn.socket.connectionTimeout = 5000
+# timeout in ms when reading data after connecting to remote repository
+org.ops4j.pax.url.mvn.socket.readTimeout = 30000
+# SO_KEEPALIVE option for sockets, defaults to false
+org.ops4j.pax.url.mvn.socket.keepAlive = false
+# SO_LINGER option for sockets, defaults to -1
+org.ops4j.pax.url.mvn.socket.linger = -1
+# SO_REUSEADDR option for sockets, defaults to false
+org.ops4j.pax.url.mvn.socket.reuseAddress = false
+# TCP_NODELAY option for sockets, defaults to true
+org.ops4j.pax.url.mvn.socket.tcpNoDelay = true
+# Configure buffer size for HTTP connections (output and input buffers), defaults to 8192 bytes
+org.ops4j.pax.url.mvn.connection.bufferSize = 8192
+# Number of connection retries after failure is detected in http client. httpclient uses default value "3"
+org.ops4j.pax.url.mvn.connection.retryCount = 3

--- a/distributions/openhab/src/main/resources/bin/karaf
+++ b/distributions/openhab/src/main/resources/bin/karaf
@@ -27,37 +27,38 @@ realpath() {
       fi
   fi
 
-  READLINK_EXISTS=$(command -v readlink &> /dev/null)
+  READLINK_EXISTS=`command -v readlink &> /dev/null`
+  BINARY_NAME=`basename "${1}"`
   if [ -z "$READLINK_EXISTS" ]; then
-    OURPWD=${PWD}
-    cd "$(dirname "${1}")" || exit 2
-    LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
+    OURPWD="`pwd`"
+    cd "`dirname "${1}"`" || exit 2
+    LINK=`ls -l "${BINARY_NAME}" | ${AWK} -F"-> " '{print $2}'`
     while [ "${LINK}" ]; do
         echo "link: ${LINK}" >&2
-        cd "$(dirname "${LINK}")" || exit 2
-        LINK=$(ls -l "$(basename "${1}")" | ${AWK} -F"-> " '{print $2}')
+        cd "`dirname "${LINK}"`" || exit 2
+        LINK=`ls -l "${BINARY_NAME}" | ${AWK} -F"-> " '{print $2}'`
     done
-    REALPATH="${PWD}/$(basename "${1}")"
+    REALPATH="`pwd`/${BINARY_NAME}"
     cd "${OURPWD}" || exit 2
     echo "${REALPATH}"
   else
-    OURPWD=${PWD}
-    cd "$(dirname "${1}")" || exit 2
-    LINK=$(readlink "$(basename "${1}")")
+    OURPWD="`pwd`"
+    cd "`dirname "${1}"`" || exit 2
+    LINK=`readlink "${BINARY_NAME}"`
     while [ "${LINK}" ]; do
-	    echo "link: ${LINK}" >&2
-        cd "$(dirname "${LINK}")" || exit 2
-        LINK=$(readlink "$(basename "${1}")")
+        echo "link: ${LINK}" >&2
+        cd "`dirname "${LINK}"`" || exit 2
+        LINK=`readlink "${BINARY_NAME}"`
     done
-    REALPATH="${PWD}/$(basename "${1}")"
+    REALPATH="`pwd`/${BINARY_NAME}"
     cd "${OURPWD}" || exit 2
     echo "${REALPATH}"
   fi
 }
 
-REALNAME=$(realpath "$0")
-DIRNAME=$(dirname "${REALNAME}")
-PROGNAME=$(basename "${REALNAME}")
+REALNAME=`realpath "$0"`
+DIRNAME=`dirname "${REALNAME}"`
+PROGNAME=`basename "${REALNAME}"`
 LOCAL_CLASSPATH=$CLASSPATH
 
 #
@@ -76,7 +77,7 @@ fi
 
 forceNoRoot() {
     # If configured, prevent execution as root
-    if [ "${KARAF_NOROOT}" ] && [ "$(id -u)" -eq 0 ]; then
+    if [ "${KARAF_NOROOT}" ] && [ "`id -u`" -eq 0 ]; then
         die "Do not run as root!"
     fi
 }
@@ -107,13 +108,13 @@ checkRootInstance() {
    ROOT_INSTANCE_RUNNING=false
    if [ -f "${KARAF_DATA}/tmp/instances/instance.properties" ];
    then
-      ROOT_INSTANCE_PID=$(sed -n -e '/item.0.pid/ s/.*\= *//p' "${KARAF_DATA}/tmp/instances/instance.properties")
-      ROOT_INSTANCE_NAME=$(sed -n -e '/item.0.name/ s/.*\= *//p' "${KARAF_DATA}/tmp/instances/instance.properties")
+      ROOT_INSTANCE_PID=`sed -n -e '/item.0.pid/ s/.*\= *//p' "${KARAF_DATA}/tmp/instances/instance.properties"`
+      ROOT_INSTANCE_NAME=`sed -n -e '/item.0.name/ s/.*\= *//p' "${KARAF_DATA}/tmp/instances/instance.properties"`
       if [ "${ROOT_INSTANCE_PID}" -ne "0" ]; then
           if ps -p "${ROOT_INSTANCE_PID}" > /dev/null
           then
               MAIN=org.apache.karaf.main.Main
-              PID_COMMAND=$("${PS_PREFIX}"ps -p "${ROOT_INSTANCE_PID}" -o args | sed 1d)
+              PID_COMMAND=`"${PS_PREFIX}"ps -p "${ROOT_INSTANCE_PID}" -o args | sed 1d`
 
               if [ "${PID_COMMAND#*$MAIN}" != "$PID_COMMAND" ]; then
                 ROOT_INSTANCE_RUNNING=true
@@ -180,9 +181,9 @@ run() {
     JAVA_ENDORSED_DIRS="${JAVA_HOME}/jre/lib/endorsed:${JAVA_HOME}/lib/endorsed:${KARAF_HOME}/lib/endorsed"
     JAVA_EXT_DIRS="${JAVA_HOME}/jre/lib/ext:${JAVA_HOME}/lib/ext:${KARAF_HOME}/lib/ext"
     if ${cygwin}; then
-        JAVA_HOME=$(cygpath --path --windows "${JAVA_HOME}")
-        JAVA_ENDORSED_DIRS=$(cygpath --path --windows "${JAVA_ENDORSED_DIRS}")
-        JAVA_EXT_DIRS=$(cygpath --path --windows "${JAVA_EXT_DIRS}")
+        JAVA_HOME=`cygpath --path --windows "${JAVA_HOME}"`
+        JAVA_ENDORSED_DIRS=`cygpath --path --windows "${JAVA_ENDORSED_DIRS}"`
+        JAVA_EXT_DIRS=`cygpath --path --windows "${JAVA_EXT_DIRS}"`
     fi
     convertPaths
     cd "${KARAF_BASE}" || exit 2
@@ -296,8 +297,8 @@ run() {
                 ${KARAF_EXEC} "${JAVA}" ${JAVA_OPTS} \
                     --add-reads=java.xml=java.logging \
                     --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED \
-                    --patch-module java.base=lib/endorsed/org.apache.karaf.specs.locator-4.2.4.jar \
-                    --patch-module java.xml=lib/endorsed/org.apache.karaf.specs.java.xml-4.2.4.jar \
+                    --patch-module java.base=lib/endorsed/org.apache.karaf.specs.locator-4.2.6.jar \
+                    --patch-module java.xml=lib/endorsed/org.apache.karaf.specs.java.xml-4.2.6.jar \
                     --add-opens java.base/java.security=ALL-UNNAMED \
                     --add-opens java.base/java.net=ALL-UNNAMED \
                     --add-opens java.base/java.lang=ALL-UNNAMED \

--- a/distributions/openhab/src/main/resources/bin/karaf.bat
+++ b/distributions/openhab/src/main/resources/bin/karaf.bat
@@ -420,8 +420,8 @@ if "%KARAF_PROFILER%" == "" goto :RUN
             "%JAVA%" %JAVA_OPTS% %OPTS% ^
                 --add-reads=java.xml=java.logging ^
                 --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED ^
-                --patch-module java.base=lib/endorsed/org.apache.karaf.specs.locator-4.2.4.jar ^
-                --patch-module java.xml=lib/endorsed/org.apache.karaf.specs.java.xml-4.2.4.jar ^
+                --patch-module java.base=lib/endorsed/org.apache.karaf.specs.locator-4.2.6.jar ^
+                --patch-module java.xml=lib/endorsed/org.apache.karaf.specs.java.xml-4.2.6.jar ^
                 --add-opens java.base/java.security=ALL-UNNAMED ^
                 --add-opens java.base/java.net=ALL-UNNAMED ^
                 --add-opens java.base/java.lang=ALL-UNNAMED ^

--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -105,35 +105,6 @@
 		<Set name="EndpointIdentificationAlgorithm"></Set>
 		<Set name="NeedClientAuth"><SystemProperty name="jetty.ssl.needClientAuth" default="false" /></Set>
 		<Set name="WantClientAuth"><SystemProperty name="jetty.ssl.wantClientAuth" default="false" /></Set>
-		<Set name="ExcludeCipherSuites">
-			<Array type="String">
-				<Item>SSL_RSA_WITH_DES_CBC_SHA</Item>
-				<Item>SSL_DHE_RSA_WITH_DES_CBC_SHA</Item>
-				<Item>SSL_DHE_DSS_WITH_DES_CBC_SHA</Item>
-				<Item>SSL_RSA_EXPORT_WITH_RC4_40_MD5</Item>
-				<Item>SSL_RSA_EXPORT_WITH_DES40_CBC_SHA</Item>
-				<Item>SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA</Item>
-				<!-- Disable cipher suites with Diffie-Hellman key exchange to prevent Logjam attack and avoid the ssl_error_weak_server_ephemeral_dh_key error in recent browsers -->
-				<Item>SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA</Item>
-				<Item>SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA</Item>
-				<Item>TLS_DHE_RSA_WITH_AES_256_CBC_SHA256</Item>
-				<Item>TLS_DHE_DSS_WITH_AES_256_CBC_SHA256</Item>
-				<Item>TLS_DHE_RSA_WITH_AES_256_CBC_SHA</Item>
-				<Item>TLS_DHE_DSS_WITH_AES_256_CBC_SHA</Item>
-				<Item>TLS_DHE_RSA_WITH_AES_128_CBC_SHA256</Item>
-				<Item>TLS_DHE_DSS_WITH_AES_128_CBC_SHA256</Item>
-				<Item>TLS_DHE_RSA_WITH_AES_128_CBC_SHA</Item>
-				<Item>TLS_DHE_DSS_WITH_AES_128_CBC_SHA</Item>
-			</Array>
-		</Set>
-		<!-- setting required for preventing Poodle attack, see http://stackoverflow.com/questions/26382540/how-to-disable-the-sslv3-protocol-in-jetty-to-prevent-poodle-attack/26388531#26388531 -->
-		<Set name="ExcludeProtocols">
-			<Array type="java.lang.String">
-				<Item>SSLv3</Item>
-			</Array>
-		</Set>
-
-
 	</New>
 
 

--- a/distributions/openhab/src/main/resources/userdata/etc/org.apache.karaf.shell.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.apache.karaf.shell.cfg
@@ -35,6 +35,16 @@ sshHost = 127.0.0.1
 sshIdleTimeout = 1800000
 
 #
+# Define the number of the NIO workers for the sshd server. Default is 2.
+#
+#nio-workers = 2
+
+#
+# Define the maximum number of SSH sessions. Default is unlimited.
+#
+#max-concurrent-sessions = -1
+
+#
 # sshRealm defines which JAAS domain to use for password authentication.
 #
 sshRealm = karaf

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
 
         <jackson.version>1.9.13</jackson.version>
 
-        <karaf.version>4.2.4</karaf.version>
-        <jetty.version>9.4.12.v20180830</jetty.version>
+        <karaf.version>4.2.6</karaf.version>
+        <jetty.version>9.4.18.v20190429</jetty.version>
 
         <!-- provided by Karaf -->
         <dep.slf4j.api.groupId>org.slf4j</dep.slf4j.api.groupId>


### PR DESCRIPTION
For Karaf 4.2.5 release notes, see:
  https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12345153

For Karaf 4.2.6 release notes, see:
  https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12345365

---

Should be merged together with:

* https://github.com/openhab/openhab-core/pull/859
* https://github.com/openhab/openhab2-addons/pull/5708
* https://github.com/openhab/openhab-webui/pull/79

---

There's also a [openhab-2.5.0-SNAPSHOT.tar.gz](https://github.com/wborn/openhab-distro/releases/download/2.5.0-k426.20190609/openhab-2.5.0-SNAPSHOT.tar.gz) which can be used for testing. It's using Karaf build from the https://github.com/apache/karaf/tree/karaf-4.2.6 tag.