### PR TITLE
migrate from EclipseSource JAX-RS publisher to openHAB one

### DIFF
--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -32,7 +32,7 @@ feature.openhab-base: \
     bnd.identity;id='org.openhab.core.io.net',\
     bnd.identity;id='org.openhab.core.io.http',\
     bnd.identity;id='org.openhab.core.io.rest',\
-    bnd.identity;id='org.openhab.core.io.rest.optimize',\
+    bnd.identity;id='org.openhab.core.io.rest.publisher',\
     bnd.identity;id='org.openhab.core.io.rest.core',\
     bnd.identity;id='org.openhab.core.io.rest.sse'
 
@@ -84,7 +84,6 @@ feature.openhab-model-runtime-all: \
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.eclipsesource.jaxrs.jersey-all;version='[2.22.2,2.22.3)',\
-	com.eclipsesource.jaxrs.publisher;version='[5.3.1,5.3.2)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	com.google.guava;version='[21.0.0,21.0.1)',\
 	com.google.inject;version='[3.0.0,3.0.1)',\
@@ -169,7 +168,7 @@ feature.openhab-model-runtime-all: \
 	org.openhab.core.io.net;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.rest;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.rest.core;version='[2.5.0,2.5.1)',\
-	org.openhab.core.io.rest.optimize;version='[2.5.0,2.5.1)',\
+	org.openhab.core.io.rest.publisher;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.rest.sitemap;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.rest.sse;version='[2.5.0,2.5.1)',\
 	org.openhab.core.model.core;version='[2.5.0,2.5.1)',\


### PR DESCRIPTION
This PR requires the related change in openHAB Core.

Related to: https://github.com/openhab/openhab-core/pull/905