### PR TITLE
[pushbullet] add note about retired pushbullet action

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -26,6 +26,7 @@ ALERT;REST Docs: This add-on is now part of the UIs. When installing it using te
 ALERT;EnOcean Binding: Channel 'receivingState' has been removed, because this was a string containing many information. For this, there are three new channels: 'rssi', 'repeatCount' and 'lastReceived'.
 ALERT;Mail Action: The mail action has been replaced by a new mail binding.
 ALERT;Homekit: Some tags have been renamed. Old names will not be supported in future versions. Please check documentation.
+ALERT;Pushbullet Action: The pushbullet action has been replaced by a new pushbullet binding.
 
 [[PRE]]
 [2.2.0]


### PR DESCRIPTION
Depends on:

* ~~https://github.com/openhab/openhab2-addons/pull/5668~~
*  PR has been merged into OH2 HEAD
* ~~https://github.com/openhab/openhab1-addons/pull/5874~~
*  PR has been merged into distro HEAD

Signed-off-by: Hakan Tandogan <hakan@tandogan.com>