### PR TITLE
Added launch files for model projects and UI projects and added them to the IDE oomph setup

### DIFF
--- a/launch/ModelGen.launch
+++ b/launch/ModelGen.launch
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+<booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+<stringAttribute key="M2_GOALS" value="-DskipChecks -DskipTests clean install -am -pl bundles/org.openhab.core.model.core -pl bundles/org.openhab.core.model.item -pl bundles/org.openhab.core.model.item.ide -pl bundles/org.openhab.core.model.lazygen -pl bundles/org.openhab.core.model.persistence -pl bundles/org.openhab.core.model.persistence.ide -pl bundles/org.openhab.core.model.rule -pl bundles/org.openhab.core.model.rule.ide -pl bundles/org.openhab.core.model.script -pl bundles/org.openhab.core.model.script.ide -pl bundles/org.openhab.core.model.sitemap -pl bundles/org.openhab.core.model.sitemap.ide -pl bundles/org.openhab.core.model.thing -pl bundles/org.openhab.core.model.thing.ide"/>
+<booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+<booleanAttribute key="M2_OFFLINE" value="false"/>
+<stringAttribute key="M2_PROFILES" value=""/>
+<listAttribute key="M2_PROPERTIES"/>
+<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+<booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+<intAttribute key="M2_THREADS" value="1"/>
+<booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+<stringAttribute key="M2_USER_SETTINGS" value=""/>
+<booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+<mapAttribute key="org.eclipse.debug.core.environmentVariables">
+<mapEntry key="QT_QPA_PLATFORM" value=""/>
+</mapAttribute>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JRE for JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.openhab.core}/../.."/>
+</launchConfiguration>

--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2345,6 +2345,9 @@
             name="Infrastructure">
         <predicate
             xsi:type="predicates:LocationPredicate"
+            pattern=".*/launch"/>
+        <predicate
+            xsi:type="predicates:LocationPredicate"
             pattern=".*/launch/.*"/>
         <predicate
             xsi:type="predicates:LocationPredicate"
@@ -2509,16 +2512,6 @@
       <sourceLocator
           rootFolder="${git.clone.webui.location}"/>
     </setupTask>
-    <setupTask
-        xsi:type="launching:LaunchTask"
-        id="launch.paperui"
-        excludedTriggers="STARTUP"
-        launcher="PaperUI Setup"/>
-    <setupTask
-        xsi:type="launching:LaunchTask"
-        id="launch.basicui"
-        excludedTriggers="STARTUP"
-        launcher="BasicUI Setup"/>
     <stream
         name="master"
         label=""/>
@@ -2560,19 +2553,25 @@
     <setupTask
         xsi:type="projects:ProjectsImportTask">
       <sourceLocator
-          rootFolder="${git.clone.openhabcore.location}"
+          rootFolder="${git.clone.openhabcore.location}/bom"
+          locateNestedProjects="true"/>
+      <sourceLocator
+          rootFolder="${git.clone.openhabcore.location}/bundles"
+          locateNestedProjects="true"/>
+      <sourceLocator
+          rootFolder="${git.clone.openhabcore.location}/itests"
           locateNestedProjects="true"/>
     </setupTask>
     <setupTask
         xsi:type="launching:LaunchTask"
-        id="launch.openhabcore.all"
+        id="launch.model.gen"
         excludedTriggers="STARTUP"
-        launcher="openHABCoreMavenBuild"/>
+        launcher="ModelGen"/>
     <setupTask
         xsi:type="projects:ProjectsBuildTask"
         excludedTriggers="STARTUP"
         refresh="true"
-        clean="true"/>
+        clean="false"/>
     <setupTask
         xsi:type="setup:ResourceCreationTask"
         id="lifecycle-mapping"


### PR DESCRIPTION
Implements https://github.com/openhab/openhab-distro/issues/927

- runs Maven build for model projects of openhab-core
- removes the archetype projects from the workspace
- moved the launch project to the Infrastructure working set
- removed unnecessary UI launch tasks from oomph setup

Signed-off-by: Kai Kreuzer <kai@openhab.org>