### PR TITLE
add Eclipse plugin "m2e.sourcelookup"

### DIFF
--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2346,8 +2346,12 @@
           name="org.eclipse.wst.web_ui.feature.feature.group"/>
       <requirement
           name="bndtools.m2e.feature.feature.group"/>
+      <requirement
+          name="bjmi.m2e.sourcelookup.feature.feature.group"/>
       <repository
           url="https://dl.bintray.com/bndtools/bndtools/latest/"/>
+      <repository
+          url="https://bjmi.github.io/update-site/"/>
     </setupTask>
     <setupTask
         xsi:type="git:GitCloneTask"


### PR DESCRIPTION
Eclipse Plugin that provides Maven Dependencies as Source Container in JDT Launching Configuration.

See: https://github.com/bjmi/m2e.sourcelookup/blob/master/README.md
