### PR TITLE
Add OpenSprinkler breaking changes notification

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -28,6 +28,7 @@ ALERT;Mail Action: The mail action has been replaced by a new mail binding.
 ALERT;Homekit: Some tags have been renamed. Old names will not be supported in future versions. Please check documentation.
 ALERT;Pushbullet Action: The pushbullet action has been replaced by a new pushbullet binding.
 ALERT;DarkSky Binding: The item type of `rain` and `snow` channels have been changed to `Number:Speed`.
+ALERT;OpenSprinkler Binding: The stationXX channels have been removed and replaced by a bridge/thing combination. See documentation for further information.
 
 [[PRE]]
 [2.2.0]


### PR DESCRIPTION
See the PR https://github.com/openhab/openhab2-addons/pull/5862 for more information about the changes.

Signed-off-by: Florian <florian.schmidt.welzow@t-online.de>