### PR TITLE
Add update message for removal of Systeminfo Binding 'cpu#load' channel

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -27,8 +27,9 @@ ALERT;EnOcean Binding: Channel 'receivingState' has been removed, because this w
 ALERT;Mail Action: The mail action has been replaced by a new mail binding.
 ALERT;Homekit: Some tags have been renamed. Old names will not be supported in future versions. Please check documentation.
 ALERT;Pushbullet Action: The pushbullet action has been replaced by a new pushbullet binding.
-ALERT;DarkSky Binding: The item type of `rain` and `snow` channels have been changed to `Number:Speed`.
+ALERT;DarkSky Binding: The item type of 'rain' and 'snow' channels have been changed to 'Number:Speed'.
 ALERT;OpenSprinkler Binding: The stationXX channels have been removed and replaced by a bridge/thing combination. See documentation for further information.
+ALERT;Systeminfo Binding: The 'cpu#load' channel has been removed because the OSHI library no longer provides this information.
 
 [[PRE]]
 [2.2.0]


### PR DESCRIPTION
See https://github.com/openhab/openhab2-addons/pull/5929