### PR TITLE
[tplinksmarthome] Added 2.5.0 breaking changes alert

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -29,8 +29,9 @@ ALERT;OneWire Binding: Some thing types have changed and need to be updated in t
 ALERT;OpenSprinkler Binding: The stationXX channels have been removed and replaced by a bridge/thing combination. See documentation for further information.
 ALERT;Pushbullet Action: The pushbullet action has been replaced by a new pushbullet binding.
 ALERT;REST Docs: This add-on is now part of the UIs. When installing it using textual configuration, update 'services/addons.cfg' by removing 'restdocs' from 'misc' and add it to 'ui' instead.
-ALERT;senseBox Binding: The senseBox binding is now using Units of Measurements, and the channel name for Illuminance has changed. The Items must be reconfigured.
+ALERT;SenseBox Binding: The senseBox binding is now using Units of Measurements, and the channel name for Illuminance has changed. The Items must be reconfigured.
 ALERT;Systeminfo Binding: The 'cpu#load' channel has been removed because the OSHI library no longer provides this information.
+ALERT;TP-Link Smart Home Binding: The enery and rssi channels are now using Units of Measurements. Items must be adapted and the things must be recreated.
 ALERT;Vitotronic Binding: The following channels have been renamed: 'outsite_temp' to 'outside_temp', 'pelletburner:power' to 'pelletburner:powerlevel', 'party_temp' to 'party_temp_setpoint' and 'save_temp' to 'save_temp_setpoint'
 
 [[PRE]]


### PR DESCRIPTION
Related to https://github.com/openhab/openhab2-addons/pull/6020

Also changed case of sensebox as it was the only one that didn't start with an uppercase character. 