### PR TITLE
update version of com.zsmartsystems.zigbee to 1.2.3

### DIFF
--- a/features/addons/src/main/feature/feature.xml
+++ b/features/addons/src/main/feature/feature.xml
@@ -6,11 +6,11 @@
     <feature name="openhab-binding-zigbee" description="ZigBee Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-serial</feature>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee/1.2.1</bundle>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.cc2531/1.2.1</bundle>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.ember/1.2.1</bundle>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.telegesis/1.2.1</bundle>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.xbee/1.2.1</bundle>
+        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee/1.2.3</bundle>
+        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.cc2531/1.2.3</bundle>
+        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.ember/1.2.3</bundle>
+        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.telegesis/1.2.3</bundle>
+        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.xbee/1.2.3</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee/${project.version}</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.cc2531/${project.version}</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.ember/${project.version}</bundle>


### PR DESCRIPTION
The version of the zigbee libraries in use is out-of-date.  

