### PR TITLE
Renamed service pid for regional settings from "org.eclipse.smarthome.core.localeprovider" -> "org.eclipse.smarthome.core.i18nprovider" to "org.eclipse.smarthome.i18n"

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -47,3 +47,5 @@ DELETEDIR;$OPENHAB_USERDATA/kar
 
 [2.5.0]
 REPLACE;org.eclipse.smarthome.automation.dto.RuleDTO;org.openhab.core.automation.dto.RuleDTO;$OPENHAB_USERDATA/jsondb/automation_rules.json
+MOVE;$OPENHAB_USERDATA/config/org/eclipse/smarthome/core/i18nprovider.config;$OPENHAB_USERDATA/config/org/eclipse/smarthome/i18n.config
+REPLACE;org.eclipse.smarthome.core.i18nprovider;org.eclipse.smarthome.i18n;$OPENHAB_USERDATA/config/org/eclipse/smarthome/i18n.config

--- a/distributions/openhab/src/main/resources/conf/services/runtime.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/runtime.cfg
@@ -4,13 +4,13 @@
 # The ISO 639 alpha-2 or alpha-3 language code (if there is no alpha-2 one).
 # Example: "en" (English), "de" (German), "ja" (Japanese), "kok" (Konkani)
 #
-#org.eclipse.smarthome.core.i18nprovider:language=
+#org.eclipse.smarthome.i18n:language=
 
 # The region that should be used.
 # ISO 3166 alpha-2 country code or UN M.49 numeric-3 area code.
 # Example: "US" (United States), "DE" (Germany), "FR" (France), "029" (Caribbean)
 #
-#org.eclipse.smarthome.core.i18nprovider:region=
+#org.eclipse.smarthome.i18n:region=
 
 ################ PERSISTENCE ####################
 

--- a/distributions/openhab/src/main/resources/conf/services/runtime.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/runtime.cfg
@@ -4,13 +4,13 @@
 # The ISO 639 alpha-2 or alpha-3 language code (if there is no alpha-2 one).
 # Example: "en" (English), "de" (German), "ja" (Japanese), "kok" (Konkani)
 #
-#org.eclipse.smarthome.core.localeprovider:language=
+#org.eclipse.smarthome.core.i18nprovider:language=
 
 # The region that should be used.
 # ISO 3166 alpha-2 country code or UN M.49 numeric-3 area code.
 # Example: "US" (United States), "DE" (Germany), "FR" (France), "029" (Caribbean)
 #
-#org.eclipse.smarthome.core.localeprovider:region=
+#org.eclipse.smarthome.core.i18nprovider:region=
 
 ################ PERSISTENCE ####################
 


### PR DESCRIPTION
- Renamed service pid for regional settings from "org.eclipse.smarthome.core.localeprovider" -> "org.eclipse.smarthome.core.i18nprovider" to "org.eclipse.smarthome.i18n"

According to our code the service pid is `org.eclipse.smarthome.i18nprovider`. It was not possible for me to find any reference to `org.eclipse.smarthome.core.localeprovider`.

https://github.com/openhab/openhab-core/blob/a44c55e0e00ff4c8a072385097b43c4144489708/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImpl.java#L81-L83

Depends on https://github.com/openhab/openhab-core/pull/1112

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>