### PR TITLE
[networkupstools] openHAB1 binding moved to legacy

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -26,6 +26,7 @@ ALERT;Homekit: Some tags have been renamed. Old names will not be supported in f
 ALERT;LGWebOS Binding: The binding parameter 'localIP' has been removed. The binding now uses system defaults for network communication. The thing type parameter 'deviceId' is no longer a parameter, but a property. Parameters 'host' and 'key' have been added.
 ALERT;Mail Action: The mail action has been replaced by a new mail binding.
 ALERT;MQTT Binding: Homie channel names may have changed if special characters are used for MQTT topic names.
+ALERT;Network UPS Tools: The Network UPS Tools openHAB 1 binding has been replaced by a new binding and the openHAB 1 binding has been moved to legacy.
 ALERT;OneWire Binding: Some thing types have changed and need to be updated in textual configurations. See documentation for further information.
 ALERT;OpenSprinkler Binding: The stationXX channels have been removed and replaced by a bridge/thing combination. See documentation for further information.
 ALERT;Pushbullet Action: The pushbullet action has been replaced by a new pushbullet binding.


### PR DESCRIPTION
Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>