### PR TITLE
Update org.ops4j.pax.logging.cfg

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg
@@ -13,7 +13,7 @@ log4j2.logger.shell.level = OFF
 log4j2.logger.shell.appenderRefs = stdout
 log4j2.logger.shell.appenderRef.stdout.ref = STDOUT
 
-# Security audit logger
+# Security audit logger
 log4j2.logger.audit.name = org.apache.karaf.jaas.modules.audit
 log4j2.logger.audit.level = INFO
 log4j2.logger.audit.additivity = false
@@ -124,7 +124,7 @@ log4j2.appender.event.policies.type = Policies
 log4j2.appender.event.policies.size.type = SizeBasedTriggeringPolicy
 log4j2.appender.event.policies.size.size = 16MB
 
-# Audit file appender
+# Audit file appender
 log4j2.appender.audit.type = RollingRandomAccessFile
 log4j2.appender.audit.name = AUDIT
 log4j2.appender.audit.fileName = ${openhab.logdir}/audit.log


### PR DESCRIPTION
- Replaced unicode characters - file encoding is ASCII

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>