### PR TITLE
[demo] Reduce logging output noise of demo app

### DIFF
--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -73,7 +73,8 @@ feature.openhab-model-runtime-all: \
 	smarthome.configdir=${.}/runtime/conf,\
 	smarthome.userdata=${.}/runtime/userdata,\
 	osgi.console.enable.builtin=false,\
-	logback.configurationFile=file:${.}/runtime/logback.xml
+	logback.configurationFile=file:${.}/runtime/logback.xml,\
+	log4j.configuration=file:${.}/runtime/log4j.xml
 
 -runblacklist: bnd.identity;id='org.apache.aries.javax.jax.rs-api'
 

--- a/launch/app/runtime/log4j.xml
+++ b/launch/app/runtime/log4j.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<!-- Logger for core classes -->
+<log4j:configuration xmlns:log4j='http://jakarta.apache.org/log4j/'>
+
+	<appender name="console" class="org.apache.log4j.ConsoleAppender">
+		<layout class="org.apache.log4j.EnhancedPatternLayout">
+			<param name="ConversionPattern" value="%d{HH:mm:ss.SSS} [%t] %p %C{1.}:%L - %m%n" />
+		</layout>
+	</appender>
+
+	<root>
+		<level value="WARN" />
+		<appender-ref ref="console" />
+	</root>
+
+</log4j:configuration>

--- a/launch/app/runtime/logback.xml
+++ b/launch/app/runtime/logback.xml
@@ -31,6 +31,8 @@
   <!-- log DEBUG from any log API using a logger name starting with `org.my.foo` -->
   <!-- <logger name="org.my.foo" level="DEBUG" /> -->
 
+  <!-- Ignore warnings given by ServletContainerInitializerScanner -->
+  <logger name="org.ops4j.pax.web.utils" level="ERROR" />
 
   <root level="WARN">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
During start up of the demo there is some noise in the logging. This pr intends to reduce it:
1) Reduce logging by ServletContainerInitializerScanner, See also https://github.com/openhab/openhab-core/issues/725
2) Remove warning about no logger configured by adding log4j file. Not sure what the relation is to 
[distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg](https://github.com/openhab/openhab-distro/blob/master/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg)