### PR TITLE
Fix OsgiLocator CNF and suppress XStream warnings on Java 9+

### DIFF
--- a/distributions/openhab/src/main/resources/bin/karaf
+++ b/distributions/openhab/src/main/resources/bin/karaf
@@ -297,14 +297,17 @@ run() {
                 ${KARAF_EXEC} "${JAVA}" ${JAVA_OPTS} \
                     --add-reads=java.xml=java.logging \
                     --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED \
-                    --patch-module java.base=lib/endorsed/org.apache.karaf.specs.locator-4.2.6.jar \
-                    --patch-module java.xml=lib/endorsed/org.apache.karaf.specs.java.xml-4.2.6.jar \
+                    --patch-module "java.base=${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.locator-4.2.6.jar" \
+                    --patch-module "java.xml=${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.java.xml-4.2.6.jar" \
                     --add-opens java.base/java.security=ALL-UNNAMED \
                     --add-opens java.base/java.net=ALL-UNNAMED \
                     --add-opens java.base/java.lang=ALL-UNNAMED \
                     --add-opens java.base/java.util=ALL-UNNAMED \
                     --add-opens java.naming/javax.naming.spi=ALL-UNNAMED \
                     --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED \
+                    --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
+                    --add-opens java.base/java.text=ALL-UNNAMED \
+                    --add-opens java.desktop/java.awt.font=ALL-UNNAMED \
                     --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED \
                     --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED \
                     --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED \

--- a/distributions/openhab/src/main/resources/bin/karaf.bat
+++ b/distributions/openhab/src/main/resources/bin/karaf.bat
@@ -420,14 +420,17 @@ if "%KARAF_PROFILER%" == "" goto :RUN
             "%JAVA%" %JAVA_OPTS% %OPTS% ^
                 --add-reads=java.xml=java.logging ^
                 --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED ^
-                --patch-module java.base=lib/endorsed/org.apache.karaf.specs.locator-4.2.6.jar ^
-                --patch-module java.xml=lib/endorsed/org.apache.karaf.specs.java.xml-4.2.6.jar ^
+                --patch-module "java.base=%KARAF_HOME%/lib/endorsed/org.apache.karaf.specs.locator-4.2.6.jar" ^
+                --patch-module "java.xml=%KARAF_HOME%/lib/endorsed/org.apache.karaf.specs.java.xml-4.2.6.jar" ^
                 --add-opens java.base/java.security=ALL-UNNAMED ^
                 --add-opens java.base/java.net=ALL-UNNAMED ^
                 --add-opens java.base/java.lang=ALL-UNNAMED ^
                 --add-opens java.base/java.util=ALL-UNNAMED ^
                 --add-opens java.naming/javax.naming.spi=ALL-UNNAMED ^
                 --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED ^
+                --add-opens java.base/java.lang.reflect=ALL-UNNAMED ^
+                --add-opens java.base/java.text=ALL-UNNAMED ^
+                --add-opens java.desktop/java.awt.font=ALL-UNNAMED ^
                 --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED ^
                 --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED ^
                 --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED ^


### PR DESCRIPTION
Updates the path used with the patch-module options to fix the following warning on Java 9+:

```
WARNING: package org.apache.karaf.specs.locator not in java.base
Error starting karaf activator org.apache.karaf.specs.activator.Activator: org/apache/karaf/specs/locator/OsgiLocator
```

Adds a few more "add-opens" to the Karaf scripts so we can suppress the warnings on Java 9+ caused by XStream's reflection usage.
Because XStream still works without any issues on Java 11 there is no need for users to see these warnings:

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.thoughtworks.xstream.core.util.Fields (file:/openhab/userdata/cache/org.eclipse.osgi/66/0/bundleFile) to field java.lang.reflect.Proxy.h
WARNING: Please consider reporting this to the maintainers of com.thoughtworks.xstream.core.util.Fields
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

Related to openhab/openhab-distro#768