### PR TITLE
Upgrade to Karaf 4.2.7

### DIFF
--- a/distributions/openhab-verify/pom.xml
+++ b/distributions/openhab-verify/pom.xml
@@ -20,6 +20,13 @@
             <version>${karaf.version}</version>
             <type>kar</type>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- This should have been an optional dependency and will be fixed in Karaf 4.2.8 (KARAF-6462). -->
+                    <groupId>org.knopflerfish.kf6</groupId>
+                    <artifactId>log-API</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -19,6 +19,13 @@
             <artifactId>framework</artifactId>
             <version>${karaf.version}</version>
             <type>kar</type>
+            <exclusions>
+                <exclusion>
+                    <!-- This should have been an optional dependency and will be fixed in Karaf 4.2.8 (KARAF-6462). -->
+                    <groupId>org.knopflerfish.kf6</groupId>
+                    <artifactId>log-API</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.features</groupId>

--- a/distributions/openhab/src/main/filtered-resources/userdata/etc/org.ops4j.pax.url.mvn.cfg
+++ b/distributions/openhab/src/main/filtered-resources/userdata/etc/org.ops4j.pax.url.mvn.cfg
@@ -86,7 +86,7 @@ org.ops4j.pax.url.mvn.defaultRepositories=\
 #    @id=repository.id : the id for the repository, just like in the
 #        settings.xml this is optional but recommended
 #
-# This contains the openhab, smart home and default repositories.
+# This contains the openHAB and default repositories.
 #
 org.ops4j.pax.url.mvn.repositories= \
 	${online.repo}\@id=openhab${pax.url.suffix}

--- a/distributions/openhab/src/main/resources/bin/karaf
+++ b/distributions/openhab/src/main/resources/bin/karaf
@@ -297,8 +297,8 @@ run() {
                 ${KARAF_EXEC} "${JAVA}" ${JAVA_OPTS} \
                     --add-reads=java.xml=java.logging \
                     --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED \
-                    --patch-module "java.base=${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.locator-4.2.6.jar" \
-                    --patch-module "java.xml=${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.java.xml-4.2.6.jar" \
+                    --patch-module "java.base=${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.locator-4.2.7.jar" \
+                    --patch-module "java.xml=${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.java.xml-4.2.7.jar" \
                     --add-opens java.base/java.security=ALL-UNNAMED \
                     --add-opens java.base/java.net=ALL-UNNAMED \
                     --add-opens java.base/java.lang=ALL-UNNAMED \

--- a/distributions/openhab/src/main/resources/bin/karaf.bat
+++ b/distributions/openhab/src/main/resources/bin/karaf.bat
@@ -420,8 +420,8 @@ if "%KARAF_PROFILER%" == "" goto :RUN
             "%JAVA%" %JAVA_OPTS% %OPTS% ^
                 --add-reads=java.xml=java.logging ^
                 --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED ^
-                --patch-module "java.base=%KARAF_HOME%/lib/endorsed/org.apache.karaf.specs.locator-4.2.6.jar" ^
-                --patch-module "java.xml=%KARAF_HOME%/lib/endorsed/org.apache.karaf.specs.java.xml-4.2.6.jar" ^
+                --patch-module "java.base=%KARAF_HOME%/lib/endorsed/org.apache.karaf.specs.locator-4.2.7.jar" ^
+                --patch-module "java.xml=%KARAF_HOME%/lib/endorsed/org.apache.karaf.specs.java.xml-4.2.7.jar" ^
                 --add-opens java.base/java.security=ALL-UNNAMED ^
                 --add-opens java.base/java.net=ALL-UNNAMED ^
                 --add-opens java.base/java.lang=ALL-UNNAMED ^

--- a/distributions/openhab/src/main/resources/bin/setenv
+++ b/distributions/openhab/src/main/resources/bin/setenv
@@ -45,6 +45,7 @@
 # export KARAF_DATA # Karaf data folder
 # export KARAF_BASE # Karaf base folder
 # export KARAF_ETC  # Karaf etc  folder
+# export KARAF_LOG  # Karaf log  folder
 # export KARAF_SYSTEM_OPTS # First citizen Karaf options
 # export KARAF_OPTS # Additional available Karaf options
 # export KARAF_DEBUG # Enable debug mode

--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -44,7 +44,7 @@
 						<Arg>
 							<New class="org.eclipse.jetty.rewrite.handler.RedirectRegexRule">
 								<Set name="regex">/$</Set>
-								<Set name="replacement">/start/index</Set>
+								<Set name="location">/start/index</Set>
 							</New>
 						</Arg>
 					</Call>
@@ -96,7 +96,7 @@
 	<Set name="dumpAfterStart">false</Set>
 	<Set name="dumpBeforeStop">false</Set>
 
-	<New id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory">
+	<New id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
 		<Set name="KeyStorePath"><SystemProperty name="jetty.keystore.path" default="/etc/myKeystore" /></Set>
 		<Set name="KeyStorePassword"><SystemProperty name="jetty.ssl.password" default="OBF:1uh81uha1toc1wn31toi1ugg1ugi" /></Set>
 		<Set name="KeyManagerPassword"><SystemProperty name="jetty.ssl.keypassword" default="OBF:1uh81uha1toc1wn31toi1ugg1ugi" /></Set>

--- a/distributions/openhab/src/main/resources/userdata/etc/org.apache.karaf.shell.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.apache.karaf.shell.cfg
@@ -113,21 +113,21 @@ completionMode = GLOBAL
 
 #
 # Override allowed SSH cipher algorithms.
-# Default: aes128-ctr,arcfour128,aes128-cbc,3des-cbc,blowfish-cbc
+# Default: aes256-ctr,aes192-ctr,aes128-ctr
 #
-# ciphers = aes128-ctr,arcfour128,aes128-cbc,3des-cbc,blowfish-cbc
+# ciphers = aes256-ctr,aes192-ctr,aes128-ctr
 
 #
 # Override allowed SSH HMAC algorithms.
-# Default: hmac-sha2-512,hmac-sha2-256,hmac-sha1
+# Default: hmac-sha2-512,hmac-sha2-256
 #
-# macs = hmac-sha2-512,hmac-sha2-256,hmac-sha1
+# macs = hmac-sha2-512,hmac-sha2-256
 
 #
 # Override allowed SSH key exchange algorithms.
-# Default: diffie-hellman-group-exchange-sha256,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1
+# Default: ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
 #
-# kexAlgorithms = diffie-hellman-group-exchange-sha256,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1
+# kexAlgorithms = ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
 
 #
 # Override moduli-url.

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
 
         <jackson.version>1.9.13</jackson.version>
 
-        <karaf.version>4.2.6</karaf.version>
-        <jetty.version>9.4.18.v20190429</jetty.version>
+        <karaf.version>4.2.7</karaf.version>
+        <jetty.version>9.4.20.v20190813</jetty.version>
 
         <!-- provided by Karaf -->
         <dep.slf4j.api.groupId>org.slf4j</dep.slf4j.api.groupId>


### PR DESCRIPTION
For Karaf 4.2.7 release notes, see:

https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12345539

The Jetty configuration in jetty.xml has been updated to fix warnings resulting from deprecations.

---

Should be merged together with:

* https://github.com/openhab/openhab-core/pull/1197
* https://github.com/openhab/openhab2-addons/pull/6368
* https://github.com/openhab/openhab-webui/pull/139

Fixes https://github.com/openhab/openhab-distro/issues/995