### PR TITLE
Suppress missing cipher warnings

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.ops4j.pax.logging.cfg
@@ -85,6 +85,11 @@ log4j2.logger.lsp4j.level = OFF
 log4j2.logger.karservice.name = org.apache.karaf.kar.internal.KarServiceImpl
 log4j2.logger.karservice.level = ERROR
 
+# Filters warnings about unavailable ciphers when JCE is not installed, see
+# https://github.com/openhab/openhab-distro/issues/999
+log4j2.logger.sshutils.name = org.apache.karaf.shell.ssh.SshUtils
+log4j2.logger.sshutils.level = ERROR
+
 # Filters known issues of javax.mail, see
 # https://github.com/openhab/openhab2-addons/issues/5530
 log4j2.logger.javaxmail.name = javax.mail


### PR DESCRIPTION
We want to use the stronger (JCE only) ciphers when available but not log warnings when they are not.

Fixes #999