### PR TITLE
Add "add-opens" for java.io for Java 9+

### DIFF
--- a/distributions/openhab/src/main/resources/bin/karaf
+++ b/distributions/openhab/src/main/resources/bin/karaf
@@ -305,6 +305,7 @@ run() {
                     --add-opens java.base/java.util=ALL-UNNAMED \
                     --add-opens java.naming/javax.naming.spi=ALL-UNNAMED \
                     --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED \
+                    --add-opens java.base/java.io=ALL-UNNAMED \
                     --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
                     --add-opens java.base/java.text=ALL-UNNAMED \
                     --add-opens java.desktop/java.awt.font=ALL-UNNAMED \

--- a/distributions/openhab/src/main/resources/bin/karaf.bat
+++ b/distributions/openhab/src/main/resources/bin/karaf.bat
@@ -428,6 +428,7 @@ if "%KARAF_PROFILER%" == "" goto :RUN
                 --add-opens java.base/java.util=ALL-UNNAMED ^
                 --add-opens java.naming/javax.naming.spi=ALL-UNNAMED ^
                 --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED ^
+                --add-opens java.base/java.io=ALL-UNNAMED ^
                 --add-opens java.base/java.lang.reflect=ALL-UNNAMED ^
                 --add-opens java.base/java.text=ALL-UNNAMED ^
                 --add-opens java.desktop/java.awt.font=ALL-UNNAMED ^


### PR DESCRIPTION
Suppresses the following warnings when using Basic UI on Java 9+

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.gson.internal.bind.ReflectiveTypeAdapterFactory (file:/openhab/userdata/cache/org.eclipse.osgi/20/0/bundleFile) to field java.io.ByteArrayOutputStream.buf
WARNING: Please consider reporting this to the maintainers of com.google.gson.internal.bind.ReflectiveTypeAdapterFactory
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

Related to #768