### PR TITLE
Create .bak file when using REPLACE during upgrade

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update
+++ b/distributions/openhab/src/main/resources/bin/update
@@ -171,7 +171,7 @@ runCommand() {
       # Avoid error if file does not exist
       if [ -f "$param3" ]; then
         echo "  Replacing: String $param1 to $param2 in file $param3"
-        sed -i "s:$param1:$param2:g" "$param3"
+        sed -i'.bak' -e "s:$param1:$param2:g" "$param3"
       fi
     ;;
     'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;


### PR DESCRIPTION
 - Makes the command Mac OS compatible

I have yet the chance to test, but should be able to on Linux devices soon. Please could someone test that this is working on Mac?

Fixes #987 

Signed-off-by: Ben Clark <ben@benjyc.uk>