### PR TITLE
Add missing bundles to Demo App for Java 11 compatibility

### DIFF
--- a/launch/app/app-java9plus.bndrun
+++ b/launch/app/app-java9plus.bndrun
@@ -1,0 +1,15 @@
+-include: app.bndrun
+
+-runee: JavaSE-9
+
+-runvm.java9plus: \
+	--add-opens java.base/java.io=ALL-UNNAMED,\
+	--add-opens java.base/java.lang=ALL-UNNAMED,\
+	--add-opens java.base/java.lang.reflect=ALL-UNNAMED,\
+	--add-opens java.base/java.net=ALL-UNNAMED,\
+	--add-opens java.base/java.security=ALL-UNNAMED,\
+	--add-opens java.base/java.text=ALL-UNNAMED,\
+	--add-opens java.base/java.util=ALL-UNNAMED,\
+	--add-opens java.desktop/java.awt.font=ALL-UNNAMED,\
+	--add-opens java.naming/javax.naming.spi=ALL-UNNAMED,\
+	--add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED

--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -1,48 +1,48 @@
 -resolve.effective: active
 
 feature.logging: \
-    bnd.identity;id='org.apache.felix.log',\
-    bnd.identity;id='org.apache.felix.logback'
+	bnd.identity;id='org.apache.felix.log',\
+	bnd.identity;id='org.apache.felix.logback'
 
 feature.debug: \
-    osgi.identity;filter:='(osgi.identity=org.apache.felix.webconsole)',\
-    osgi.identity;filter:='(osgi.identity=org.apache.felix.webconsole.plugins.ds)',\
-    osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.shell)',\
-    osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.runtime)',\
-    osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.command)'
+	osgi.identity;filter:='(osgi.identity=org.apache.felix.webconsole)',\
+	osgi.identity;filter:='(osgi.identity=org.apache.felix.webconsole.plugins.ds)',\
+	osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.shell)',\
+	osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.runtime)',\
+	osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.command)'
 
 feature.openhab-base: \
-    bnd.identity;id='org.openhab.core.config.core',\
-    bnd.identity;id='org.openhab.core.config.discovery',\
-    bnd.identity;id='org.openhab.core.config.dispatch',\
-    bnd.identity;id='org.openhab.core.config.xml',\
-    bnd.identity;id='org.openhab.core',\
-    bnd.identity;id='org.openhab.core.storage.mapdb',\
-    bnd.identity;id='org.openhab.core.binding.xml',\
-    bnd.identity;id='org.openhab.core.id',\
-    bnd.identity;id='org.openhab.core.semantics',\
-    bnd.identity;id='org.openhab.core.scheduler',\
-    bnd.identity;id='org.openhab.core.thing',\
-    bnd.identity;id='org.openhab.core.thing.xml',\
-    bnd.identity;id='org.openhab.core.transform',\
-    bnd.identity;id='org.openhab.core.audio',\
-    bnd.identity;id='org.openhab.core.voice',\
-    bnd.identity;id='org.openhab.core.io.console',\
-    bnd.identity;id='org.openhab.core.io.monitor',\
-    bnd.identity;id='org.openhab.core.io.net',\
-    bnd.identity;id='org.openhab.core.io.http',\
-    bnd.identity;id='org.openhab.core.io.rest',\
-    bnd.identity;id='org.openhab.core.io.rest.optimize',\
-    bnd.identity;id='org.openhab.core.io.rest.core',\
-    bnd.identity;id='org.openhab.core.io.rest.sse'
+	bnd.identity;id='org.openhab.core.config.core',\
+	bnd.identity;id='org.openhab.core.config.discovery',\
+	bnd.identity;id='org.openhab.core.config.dispatch',\
+	bnd.identity;id='org.openhab.core.config.xml',\
+	bnd.identity;id='org.openhab.core',\
+	bnd.identity;id='org.openhab.core.storage.mapdb',\
+	bnd.identity;id='org.openhab.core.binding.xml',\
+	bnd.identity;id='org.openhab.core.id',\
+	bnd.identity;id='org.openhab.core.semantics',\
+	bnd.identity;id='org.openhab.core.scheduler',\
+	bnd.identity;id='org.openhab.core.thing',\
+	bnd.identity;id='org.openhab.core.thing.xml',\
+	bnd.identity;id='org.openhab.core.transform',\
+	bnd.identity;id='org.openhab.core.audio',\
+	bnd.identity;id='org.openhab.core.voice',\
+	bnd.identity;id='org.openhab.core.io.console',\
+	bnd.identity;id='org.openhab.core.io.monitor',\
+	bnd.identity;id='org.openhab.core.io.net',\
+	bnd.identity;id='org.openhab.core.io.http',\
+	bnd.identity;id='org.openhab.core.io.rest',\
+	bnd.identity;id='org.openhab.core.io.rest.optimize',\
+	bnd.identity;id='org.openhab.core.io.rest.core',\
+	bnd.identity;id='org.openhab.core.io.rest.sse'
 
 feature.openhab-model-runtime-all: \
-    bnd.identity;id='org.openhab.core.model.item.runtime',\
-    bnd.identity;id='org.openhab.core.model.persistence.runtime',\
-    bnd.identity;id='org.openhab.core.model.rule.runtime',\
-    bnd.identity;id='org.openhab.core.model.script.runtime',\
-    bnd.identity;id='org.openhab.core.model.sitemap.runtime',\
-    bnd.identity;id='org.openhab.core.model.thing.runtime'
+	bnd.identity;id='org.openhab.core.model.item.runtime',\
+	bnd.identity;id='org.openhab.core.model.persistence.runtime',\
+	bnd.identity;id='org.openhab.core.model.rule.runtime',\
+	bnd.identity;id='org.openhab.core.model.script.runtime',\
+	bnd.identity;id='org.openhab.core.model.sitemap.runtime',\
+	bnd.identity;id='org.openhab.core.model.thing.runtime'
 
 -runrequires: \
 	bnd.identity;id='org.eclipse.equinox.metatype',\
@@ -65,22 +65,29 @@ feature.openhab-model-runtime-all: \
 	bnd.identity;id='org.openhab.ui.restdocs'
 
 -runfw: org.eclipse.osgi
+
 -runee: JavaSE-1.8
 
+-runrequires.ee: \
+	bnd.identity;id='org.apache.servicemix.specs.activation-api-1.1',\
+	bnd.identity;id='org.apache.servicemix.specs.annotation-api-1.3',\
+	bnd.identity;id='org.apache.servicemix.specs.jaxb-api-2.2'
+
 -runproperties: \
+	log4j.configuration=file:${.}/runtime/log4j.xml,\
+	logback.configurationFile=file:${.}/runtime/logback.xml,\
+	org.osgi.framework.bootdelegation="sun.misc",\
+	org.osgi.service.http.port=8080,\
 	osgi.console=,\
+	osgi.console.enable.builtin=false,\
 	smarthome.servicepid=org.openhab,\
 	smarthome.configdir=${.}/runtime/conf,\
-	smarthome.userdata=${.}/runtime/userdata,\
-	osgi.console.enable.builtin=false,\
-	logback.configurationFile=file:${.}/runtime/logback.xml,\
-	log4j.configuration=file:${.}/runtime/log4j.xml,\
-	org.osgi.service.http.port=8080,\
-	org.osgi.framework.bootdelegation="sun.misc"
+	smarthome.userdata=${.}/runtime/userdata
 
--runblacklist: bnd.identity;id='org.apache.aries.javax.jax.rs-api',\
-    bnd.identity;id='org.apache.aries.jpa.container',\
-    bnd.identity;id='org.openhab.core.test'
+-runblacklist: \
+	bnd.identity;id='org.apache.aries.javax.jax.rs-api',\
+	bnd.identity;id='org.apache.aries.jpa.container',\
+	bnd.identity;id='org.openhab.core.test'
 
 #
 # done
@@ -156,8 +163,6 @@ feature.openhab-model-runtime-all: \
 	org.eclipse.jetty.websocket.client;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.websocket.common;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.xml;version='[9.4.20,9.4.21)',\
-	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
-	org.glassfish.hk2.utils;version='[2.4.0,2.4.1)',\
 	org.ops4j.pax.swissbox.optional.jcl;version='[1.8.3,1.8.4)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.11,7.2.12)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.11,7.2.12)',\
@@ -218,4 +223,8 @@ feature.openhab-model-runtime-all: \
 	org.openhab.ui.iconset.classic;version='[3.0.0,3.0.1)',\
 	org.openhab.ui.paper;version='[3.0.0,3.0.1)',\
 	org.openhab.ui.restdocs;version='[3.0.0,3.0.1)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	slf4j.simple;version='[1.7.21,1.7.22)',\
+	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
+	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
+	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
+	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)'


### PR DESCRIPTION
The Demo App can be used with both Java 8 and Java 11 when adding the same runrequires as used with itest projects.
The PR also makes the indentation more consistent by using tabs instead of spaces everywhere in app.bndrun.

Related to https://github.com/openhab/openhab-distro/issues/768