### PR TITLE
Fix textual configuration

### DIFF
--- a/features/distro-resources/src/main/resources/services/basicui.cfg
+++ b/features/distro-resources/src/main/resources/services/basicui.cfg
@@ -1,5 +1,5 @@
 # Defining the default sitemap to use
-org.eclipse.smarthome.basicui:defaultSitemap=demo
+defaultSitemap=demo
 
 # The icon type to use, either png or svg
-org.eclipse.smarthome.basicui:iconType=svg
+iconType=svg

--- a/features/distro-resources/src/main/resources/services/classicui.cfg
+++ b/features/distro-resources/src/main/resources/services/classicui.cfg
@@ -1,9 +1,9 @@
 # Defining the default sitemap to use
-org.eclipse.smarthome.classicui:defaultSitemap=demo
+defaultSitemap=demo
 
 # The icon type to use, either png or svg
-#org.eclipse.smarthome.classicui:iconType=
+#iconType=
 
 # Disable in-memory caching of html fragments
 # If this is true, on every request the html files are loaded from disk (default is false)
-#org.eclipse.smarthome.classicui:disableHtmlCache=false
+#disableHtmlCache=false

--- a/launch/app/runtime/conf/smarthome.cfg
+++ b/launch/app/runtime/conf/smarthome.cfg
@@ -5,12 +5,12 @@ org.eclipse.smarthome.folder:scripts=script
 org.eclipse.smarthome.folder:persistence=persist
 org.eclipse.smarthome.folder:things=things
 
-org.eclipse.smarthome.classicui:defaultSitemap=demo
+org.openhab.classicui:defaultSitemap=demo
 
-org.eclipse.smarthome.basicui:defaultSitemap=demo
-org.eclipse.smarthome.basicui:enableIcons=true
-org.eclipse.smarthome.basicui:condensedLayout=false
-org.eclipse.smarthome.basicui:capitalizeValues=false
+org.openhab.basicui:defaultSitemap=demo
+org.openhab.basicui:enableIcons=true
+org.openhab.basicui:condensedLayout=false
+org.openhab.basicui:capitalizeValues=false
 
 org.jupnp:threadPoolSize=20
 


### PR DESCRIPTION
The UI configuration keys changed from org.eclipse.smarthome to org.openhab

See also: https://github.com/openhab/openhab-webui/issues/33