### PR TITLE
fixed online repo release url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
             </activation>
             <properties>
                 <build.number>Release Build</build.number>
-                <online.repo>${oh.repo.distBaseUrl}/online-repo/${online.repo.version}</online.repo>
+                <online.repo>https://dl.bintray.com/openhab/mvn/online-repo/${online.repo.version}</online.repo>
                 <pax.url.suffix/>
             </properties>
         </profile>


### PR DESCRIPTION
This got broken through https://github.com/openhab/openhab-distro/pull/919/files#diff-600376dffeb79835ede4a0b285078036R169

Note: `${oh.repo.snapshotBaseUrl}` references api.bintray.com and not dl.bintray.com, which results in an "Not authorized" error when trying to download artifacts.

Signed-off-by: Kai Kreuzer <kai@openhab.org>