### PR TITLE
#1016 - Fix null pointer in checking if openhab is running

### DIFF
--- a/distributions/openhab/src/main/resources/bin/common.psm1
+++ b/distributions/openhab/src/main/resources/bin/common.psm1
@@ -136,7 +136,7 @@ function GetOpenHABDirectory() {
 
 function CheckOpenHABRunning() {
     $m = (Get-WmiObject Win32_Process -Filter "name = 'java.exe'" |
-            Where-Object { $_.CommandLine.Contains("openhab") } | Measure-Object)
+		Where-Object { $_ -ne $null -and $_.CommandLine -ne $null -and $_.CommandLine.Contains("openhab") } | Measure-Object)
     if ($m.Count -gt 0) {
         throw "openHAB seems to be running, stop it before running this update script"
     }


### PR DESCRIPTION
This fixes the common.psm1 script to check for a null (to prevent an NPE if openHAB is not currently running)

Signed-off-by: Tim Roberts <timmarkroberts@gmail.com>