### PR TITLE
Removed 1.x compatibility layer

### DIFF
--- a/features/distro/src/main/feature/feature.xml
+++ b/features/distro/src/main/feature/feature.xml
@@ -58,7 +58,6 @@
 
     <feature name="openhab-package-expert" description="openHAB Expert Package" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <feature>openhab-runtime-compat1x</feature>
         <config name="org.openhab.addons" append="true">
 			package = expert
 			ui = classic,basic,paper,habpanel,habmin,restdocs

--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -56,7 +56,6 @@ feature.openhab-model-runtime-all: \
 	bnd.identity;id='org.openhab.core.automation.module.script',\
 	bnd.identity;id='org.openhab.core.automation.module.script.rulesupport',\
 	bnd.identity;id='org.openhab.core.automation.rest',\
-	bnd.identity;id='org.openhab.core.compat1x',\
 	bnd.identity;id='org.openhab.ui.basic',\
 	bnd.identity;id='org.openhab.ui.paper',\
 	bnd.identity;id='org.openhab.core.ui.icon',\
@@ -97,7 +96,6 @@ feature.openhab-model-runtime-all: \
 	jollyday;version='[0.5.8,0.5.9)',\
 	log4j;version='[1.2.17,1.2.18)',\
 	org.antlr.runtime;version='[3.2.0,3.2.1)',\
-	org.apache.commons.codec;version='[1.10.0,1.10.1)',\
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
 	org.apache.commons.fileupload;version='[1.3.3,1.3.4)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
@@ -113,7 +111,6 @@ feature.openhab-model-runtime-all: \
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
 	org.apache.felix.webconsole;version='[4.3.4,4.3.5)',\
 	org.apache.felix.webconsole.plugins.ds;version='[2.0.8,2.0.9)',\
-	org.apache.servicemix.bundles.commons-httpclient;version='[3.1.0,3.1.1)',\
 	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
@@ -172,7 +169,6 @@ feature.openhab-model-runtime-all: \
 	org.openhab.core.automation.rest;version='[3.0.0,3.0.1)',\
 	org.openhab.core.binding.xml;version='[3.0.0,3.0.1)',\
 	org.openhab.core.boot;version='[3.0.0,3.0.1)',\
-	org.openhab.core.compat1x;version='[3.0.0,3.0.1)',\
 	org.openhab.core.config.core;version='[3.0.0,3.0.1)',\
 	org.openhab.core.config.discovery;version='[3.0.0,3.0.1)',\
 	org.openhab.core.config.dispatch;version='[3.0.0,3.0.1)',\


### PR DESCRIPTION
- Removed 1.x compatibility layer

See https://github.com/openhab/openhab-core/pull/1284

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>