### PR TITLE
Update demo app version to 2.5.1-SNAPSHOT

### DIFF
--- a/launch/app/pom.xml
+++ b/launch/app/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.openhab.demo</groupId>
   <artifactId>org.openhab.demo.app</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
+  <version>2.5.1-SNAPSHOT</version>
 
   <name>openHAB Demo :: App</name>
 


### PR DESCRIPTION
@kaikreuzer Is this left at ```2.5.0-SNAPSHOT``` for a reason?

Currently I'm fighting to get the ZigBee binding to run in the IDE. While the IDE version is compiling, when it runs, it seems to be running a ```2.5.0 SNAPSHOT``` version from mid December which then throws exceptions as the source is not inline with the code as they pull in different libraries.  I suspect that the reason it's running the ```2.5.0-SNAPSHOT``` version stems from this, but when I change this to ```2.5.1-SNAPSHOT``` I get dependency errors in the pom - **hence merging this change will break the build**. 

So, the question is - should this be ```2.5.0-SNAPSHOT``` or ```2.5.1-SNAPSHOT```, and the followup is why changing the 2.5.1-SNAPSHOT causes the dependency problems below.

![image](https://user-images.githubusercontent.com/1041475/71593576-a3824380-2b2c-11ea-8593-5ffa33e963ed.png)

Signed-off-by: Chris Jackson <chris@cd-jackson.com>