### PR TITLE
Update copyright headers to 2020 (2.5.x)

### DIFF
--- a/launch/app/src/main/java/config/package-info.java
+++ b/launch/app/src/main/java/config/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2019 Contributors to the openHAB project
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.


### PR DESCRIPTION
Signed-off-by: Wouter Born <github@maindrain.net>