### PR TITLE
Update ZSS ZigBee libraries to 1.2.9

### DIFF
--- a/features/addons/src/main/feature/feature.xml
+++ b/features/addons/src/main/feature/feature.xml
@@ -6,16 +6,20 @@
     <feature name="openhab-binding-zigbee" description="ZigBee Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-serial</feature>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee/1.2.3</bundle>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.cc2531/1.2.3</bundle>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.ember/1.2.3</bundle>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.telegesis/1.2.3</bundle>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.xbee/1.2.3</bundle>
+        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee/1.2.9</bundle>
+        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.cc2531/1.2.9</bundle>
+        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.ember/1.2.9</bundle>
+        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.telegesis/1.2.9</bundle>
+        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.xbee/1.2.9</bundle>
+        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.console/1.2.9</bundle>
+        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.console.ember/1.2.9</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee/${project.version}</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.cc2531/${project.version}</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.ember/${project.version}</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.telegesis/${project.version}</bundle>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.xbee/${project.version}</bundle>
+        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.console/${project.version}</bundle>
+        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.console.ember/${project.version}</bundle>
     </feature>
     
     <feature name="openhab-binding-zwave" description="Z-Wave Binding" version="${project.version}">


### PR DESCRIPTION
This updates to the latest ZSmart Systems ZigBee Libraries ```1.2.9```. It also adds the console bundles into the feature so these are available to users without manual installation.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>