### PR TITLE
Use the latest 1.14.x add-on from Maven

### DIFF
--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -172,7 +172,10 @@
                     <configuration>
                     <tasks>
                         <replace token="/${project.version}" value="/[2.5.0,2.6)" dir="target/assembly/system/org/openhab/distro/openhab-addons/${project.version}">                                 
-                        <include name="*.xml"/>
+                            <include name="*.xml"/>
+                        </replace>
+                        <replace token="/${oh1.version}" value="/[1.14.0,1.15)" dir="target/assembly/system/org/openhab/distro/openhab-addons/${project.version}">                                 
+                            <include name="*.xml"/>
                         </replace>
                     </tasks>
                     </configuration>


### PR DESCRIPTION
This is a safety measure to potentially allow to ship patches for 1.x add-ons in future.
As 2.5.1 is our last distro, this change will make it possible to nonetheless receive 1.x add-on patches with it, similar to how it already receives 2.5.x add-on patches.

Signed-off-by: Kai Kreuzer <kai@openhab.org>