### PR TITLE
[eclipse setup] Revert to java 8 to not alienate all binding developers

### DIFF
--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2295,8 +2295,8 @@
   </setupTask>
   <setupTask
       xsi:type="jdt:JRETask"
-      version="JavaSE-11"
-      location="${jre.location-11}"/>
+      version="JavaSE-1.8"
+      location="${jre.location-1.8}"/>
   <setupTask
       xsi:type="setup:EclipseIniTask"
       id="eclipse.ini.memory.start"


### PR DESCRIPTION
Since there is only 1 version of the eclipse setup making it install java 11 would mean it's completely useless for 2.5.x binding developers. So this changes reverts it. Ideally it should be an option the user can choose from. However I have no idea how to do that with the black magic of oomph :disappointed: 