### PR TITLE
Add default UI boot feature

### DIFF
--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -139,6 +139,7 @@
                         <feature>service</feature>
                         <feature>system</feature>
                         <feature>openhab-runtime-base</feature>
+                        <feature>openhab-ui-default</feature>
                     </bootFeatures>
                     <archiveZip>false</archiveZip>
                     <archiveTarGz>false</archiveTarGz>

--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -38,16 +38,6 @@
 							</New>
 						</Arg>
 					</Call>
-
-					<!-- show the dashboard as default -->
-					<Call name="addRule">
-						<Arg>
-							<New class="org.eclipse.jetty.rewrite.handler.RedirectRegexRule">
-								<Set name="regex">/$</Set>
-								<Set name="location">/start/index</Set>
-							</New>
-						</Arg>
-					</Call>
 				</New>
 			</Arg>
 		</Call>

--- a/features/distro/src/main/feature/feature.xml
+++ b/features/distro/src/main/feature/feature.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
 
+    <feature name="openhab-ui-default" description="openHAB UI" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>openhab-core-ui</feature>
+        <bundle>mvn:org.openhab.ui.bundles/org.openhab.ui/${project.version}</bundle>
+    </feature>
+
     <feature name="openhab-package-demo" description="openHAB Demo Package" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <configfile finalname="${openhab.conf}/items/demo.items" override="false">mvn:${project.groupId}/distro-resources/${project.version}/cfg/items</configfile>


### PR DESCRIPTION
Remove Jetty redirect rule to the former dashboard
since the UI will be served at the root path.

Depends on https://github.com/openhab/openhab-webui/pull/178

Signed-off-by: Yannick Schaus <github@schaus.net>