### PR TITLE
look for a Java 11 JVM

### DIFF
--- a/distributions/openhab/src/main/resources/bin/setenv
+++ b/distributions/openhab/src/main/resources/bin/setenv
@@ -135,7 +135,7 @@ locateJava() {
     fi
 
     if [ "x${JAVA_HOME}" = "x" ] && [ "${darwin}" = "true" ]; then
-        JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
+        JAVA_HOME="$(/usr/libexec/java_home -v 11)"
     fi
     if [ "x${JAVA}" = "x" ] && [ -r /etc/gentoo-release ] ; then
         JAVA_HOME=$(java-config --jre-home)


### PR DESCRIPTION
If JAVA_HOME is not set, the start script will chose Java 1.8 instead of 11, if present.

Signed-off-by: Kai Kreuzer <kai@openhab.org>