### PR TITLE
Add openhab-runtime-ui to featuresBoot

### DIFF
--- a/distributions/openhab/src/main/filtered-resources/userdata/etc/org.apache.karaf.features.cfg
+++ b/distributions/openhab/src/main/filtered-resources/userdata/etc/org.apache.karaf.features.cfg
@@ -42,7 +42,7 @@ featuresBoot = \
     service/${karaf.version}, \
     jaas/${karaf.version}, \
     openhab-runtime-base, \
-    openhab-ui-dashboard, \
+    openhab-runtime-ui, \
     deployer/${karaf.version}, \
     diagnostic/${karaf.version}, \
     bundle/${karaf.version}, \


### PR DESCRIPTION
Might address this problem: https://github.com/openhab/openhab-distro/pull/1065#issuecomment-576123598

Signed-off-by: Yannick Schaus <github@schaus.net>