### PR TITLE
[eclipsesetup] Moved lifecycle generation to openHAB Development

### DIFF
--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2354,6 +2354,12 @@
           url="https://bjmi.github.io/update-site/"/>
     </setupTask>
     <setupTask
+        xsi:type="setup:ResourceCreationTask"
+        id="lifecycle-mapping"
+        content="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xA;&lt;lifecycleMappingMetadata>&#xA;  &lt;pluginExecutions>&#xA;    &lt;pluginExecution>&#xA;      &lt;pluginExecutionFilter>&#xA;        &lt;groupId>org.codehaus.mojo&lt;/groupId>&#xA;        &lt;artifactId>build-helper-maven-plugin&lt;/artifactId>&#xA;        &lt;versionRange>1.8&lt;/versionRange>&#xA;        &lt;goals>&#xA;          &lt;goal>add-source&lt;/goal>&#xA;          &lt;goal>add-test-source&lt;/goal>&#xA;        &lt;/goals>&#xA;      &lt;/pluginExecutionFilter>&#xA;      &lt;action>&#xA;        &lt;ignore />&#xA;      &lt;/action>&#xA;    &lt;/pluginExecution>&#xA;    &lt;pluginExecution>&#xA;      &lt;pluginExecutionFilter>&#xA;        &lt;groupId>com.diffplug.spotless&lt;/groupId>&#xA;        &lt;artifactId>spotless-maven-plugin&lt;/artifactId>&#xA;        &lt;versionRange>1.24.3&lt;/versionRange>&#xA;        &lt;goals>&#xA;          &lt;goal>check&lt;/goal>&#xA;        &lt;/goals>&#xA;      &lt;/pluginExecutionFilter>&#xA;      &lt;action>&#xA;        &lt;ignore />&#xA;      &lt;/action>&#xA;    &lt;/pluginExecution>&#xA;  &lt;/pluginExecutions>&#xA;&lt;/lifecycleMappingMetadata>&#xA;"
+        targetURL="${workspace.location|uri}/.metadata/.plugins/org.eclipse.m2e.core/lifecycle-mapping-metadata.xml"
+        encoding="UTF-8"/>
+    <setupTask
         xsi:type="git:GitCloneTask"
         id="git.clone.openhab-distro"
         remoteURI="https://github.com/openhab/openhab-distro.git"
@@ -2602,12 +2608,6 @@
         xsi:type="projects:ProjectsBuildTask"
         excludedTriggers="STARTUP"
         refresh="true"/>
-    <setupTask
-        xsi:type="setup:ResourceCreationTask"
-        id="lifecycle-mapping"
-        content="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xA;&lt;lifecycleMappingMetadata>&#xA;  &lt;pluginExecutions>&#xA;    &lt;pluginExecution>&#xA;      &lt;pluginExecutionFilter>&#xA;        &lt;groupId>org.codehaus.mojo&lt;/groupId>&#xA;        &lt;artifactId>build-helper-maven-plugin&lt;/artifactId>&#xA;        &lt;versionRange>1.8&lt;/versionRange>&#xA;        &lt;goals>&#xA;          &lt;goal>add-source&lt;/goal>&#xA;          &lt;goal>add-test-source&lt;/goal>&#xA;        &lt;/goals>&#xA;      &lt;/pluginExecutionFilter>&#xA;      &lt;action>&#xA;        &lt;ignore />&#xA;      &lt;/action>&#xA;    &lt;/pluginExecution>&#xA;    &lt;pluginExecution>&#xA;      &lt;pluginExecutionFilter>&#xA;        &lt;groupId>com.diffplug.spotless&lt;/groupId>&#xA;        &lt;artifactId>spotless-maven-plugin&lt;/artifactId>&#xA;        &lt;versionRange>1.24.3&lt;/versionRange>&#xA;        &lt;goals>&#xA;          &lt;goal>check&lt;/goal>&#xA;        &lt;/goals>&#xA;      &lt;/pluginExecutionFilter>&#xA;      &lt;action>&#xA;        &lt;ignore />&#xA;      &lt;/action>&#xA;    &lt;/pluginExecution>&#xA;  &lt;/pluginExecutions>&#xA;&lt;/lifecycleMappingMetadata>&#xA;"
-        targetURL="${workspace.location|uri}/.metadata/.plugins/org.eclipse.m2e.core/lifecycle-mapping-metadata.xml"
-        encoding="UTF-8"/>
     <stream
         name="master"
         label="3.0"/>


### PR DESCRIPTION
The eclipse lifecycle configuration file was created when the openHAB-core project was installed.
But it makes more sense to generate the file when openHAB Development is selected as this configuration applies to multiple projects.