### PR TITLE
Use feature file from ZigBee repository

### DIFF
--- a/distributions/openhab-addons/pom.xml
+++ b/distributions/openhab-addons/pom.xml
@@ -42,6 +42,13 @@
             <classifier>features</classifier>
             <type>xml</type>
         </dependency>
+        <dependency>
+            <groupId>org.openhab.addons.features.karaf</groupId>
+            <artifactId>org.openhab.addons.features.karaf.zigbee</artifactId>
+            <version>${oh2.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/features/addons/src/main/feature/feature.xml
+++ b/features/addons/src/main/feature/feature.xml
@@ -2,26 +2,7 @@
 <features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
     
     <!-- these are 2.x add-ons in separate repositories (which do not have their own Karaf feature defined), so we include them here -->
-    
-    <feature name="openhab-binding-zigbee" description="ZigBee Binding" version="${project.version}">
-        <feature>openhab-runtime-base</feature>
-        <feature>openhab-transport-serial</feature>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee/1.3.0</bundle>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.cc2531/1.3.0</bundle>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.ember/1.3.0</bundle>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.telegesis/1.3.0</bundle>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.dongle.xbee/1.3.0</bundle>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.console/1.3.0</bundle>
-        <bundle start-level="80">mvn:com.zsmartsystems.zigbee/com.zsmartsystems.zigbee.console.ember/1.3.0</bundle>
-        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee/${project.version}</bundle>
-        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.cc2531/${project.version}</bundle>
-        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.ember/${project.version}</bundle>
-        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.telegesis/${project.version}</bundle>
-        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.xbee/${project.version}</bundle>
-        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.console/${project.version}</bundle>
-        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.console.ember/${project.version}</bundle>
-    </feature>
-    
+
     <feature name="openhab-binding-zwave" description="Z-Wave Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-serial</feature>


### PR DESCRIPTION
This removes the feature file definition for ZigBee and uses a file from the ZigBee repository.
https://github.com/openhab/openhab-distro/issues/1060

**Must not be merged before https://github.com/openhab/org.openhab.binding.zigbee/pull/556**, and the build will presumably fail until this is merged.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>