### PR TITLE
Update demo app version

### DIFF
--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -210,10 +210,10 @@ feature.openhab-model-runtime-all: \
 	org.openhab.core.ui;version='[2.5.0,2.5.1)',\
 	org.openhab.core.ui.icon;version='[2.5.0,2.5.1)',\
 	org.openhab.core.voice;version='[2.5.0,2.5.1)',\
-	org.openhab.transform.map;version='[2.5.1,2.5.2)',\
-	org.openhab.ui.basic;version='[2.5.1,2.5.2)',\
-	org.openhab.ui.dashboard;version='[2.5.1,2.5.2)',\
-	org.openhab.ui.iconset.classic;version='[2.5.1,2.5.2)',\
-	org.openhab.ui.paper;version='[2.5.1,2.5.2)',\
-	org.openhab.ui.restdocs;version='[2.5.1,2.5.2)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	slf4j.simple;version='[1.7.21,1.7.22)',\
+	org.openhab.transform.map;version='[2.5.3,2.5.4)',\
+	org.openhab.ui.basic;version='[2.5.3,2.5.4)',\
+	org.openhab.ui.dashboard;version='[2.5.3,2.5.4)',\
+	org.openhab.ui.iconset.classic;version='[2.5.3,2.5.4)',\
+	org.openhab.ui.paper;version='[2.5.3,2.5.4)',\
+	org.openhab.ui.restdocs;version='[2.5.3,2.5.4)'

--- a/launch/app/pom.xml
+++ b/launch/app/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.openhab.demo</groupId>
   <artifactId>org.openhab.demo.app</artifactId>
-  <version>2.5.1-SNAPSHOT</version>
+  <version>2.5.3-SNAPSHOT</version>
 
   <name>openHAB Demo :: App</name>
 


### PR DESCRIPTION
It may [save some contributors time](https://community.openhab.org/t/cannot-debug-using-demo-app-in-eclipse-if-version-is-not-updated-in-pom-xml/93017?u=wborn) when this version is properly synced because they may add dependencies using this version:

```xml
<!-- uncomment this and add the name of your binding that you want to work on
    <dependency>
      <groupId>org.openhab.addons.bundles</groupId>
      <artifactId>org.openhab.binding.YOURBINDINGNAME</artifactId>
      <version>${project.version}</version>
      <scope>runtime</scope>
    </dependency>
-->

<!-- uncomment this if you want to work on the Zigbee binding
    <dependency>
      <groupId>org.openhab.addons.bom</groupId>
      <artifactId>org.openhab.addons.bom.zigbee</artifactId>
      <version>${project.version}</version>
      <type>pom</type>
      <scope>runtime</scope>
    </dependency>
-->
```