### PR TITLE
Suppress Nashorn deprecation warnings

### DIFF
--- a/distributions/openhab/src/main/resources/bin/setenv
+++ b/distributions/openhab/src/main/resources/bin/setenv
@@ -100,6 +100,7 @@ export JAVA_OPTS="${JAVA_OPTS}
   -Djava.library.path=${OPENHAB_USERDATA}/tmp/lib
   -Djetty.host=${HTTP_ADDRESS}
   -Djetty.http.compliance=RFC2616
+  -Dnashorn.args=--no-deprecation-warning
   -Dorg.ops4j.pax.web.listening.addresses=${HTTP_ADDRESS}
   -Dorg.osgi.service.http.port=${HTTP_PORT}
   -Dorg.osgi.service.http.port.secure=${HTTPS_PORT}"

--- a/distributions/openhab/src/main/resources/bin/setenv.bat
+++ b/distributions/openhab/src/main/resources/bin/setenv.bat
@@ -114,6 +114,7 @@ set JAVA_OPTS=%JAVA_OPTS% ^
   -Djava.library.path=%OPENHAB_USERDATA%\tmp\lib ^
   -Djetty.host=%HTTP_ADDRESS% ^
   -Djetty.http.compliance=RFC2616 ^
+  -Dnashorn.args=--no-deprecation-warning ^
   -Dorg.ops4j.pax.web.listening.addresses=%HTTP_ADDRESS% ^
   -Dorg.osgi.service.http.port=%HTTP_PORT% ^
   -Dorg.osgi.service.http.port.secure=%HTTPS_PORT%

--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -69,6 +69,7 @@ feature.openhab-model-runtime-all: \
 -runproperties: \
 	log4j.configuration=file:${.}/runtime/log4j.xml,\
 	logback.configurationFile=file:${.}/runtime/logback.xml,\
+	nashorn.args=--no-deprecation-warning,\
 	org.osgi.framework.bootdelegation="sun.misc",\
 	org.osgi.service.http.port=8080,\
 	osgi.console=,\


### PR DESCRIPTION
Suppresses the Nashorn deprecation warnings that show on startup on newer Java versions:

> Warning: Nashorn engine is planned to be removed from a future JDK release

See also: https://bugs.openjdk.java.net/browse/JDK-8210140