### PR TITLE
Define openhab.servicecfg so ConfigDispatcher can find services.cfg

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/custom.system.properties
+++ b/distributions/openhab/src/main/resources/userdata/etc/custom.system.properties
@@ -1,6 +1,7 @@
 karaf.name=openhab
 karaf.local.user=openhab
 mdnsName=openhab
+openhab.servicecfg=${openhab.runtime}/services.cfg
 org.quartz.properties=${openhab.runtime}/etc/quartz.properties
 jetty.keystore.path=${openhab.userdata}/etc/keystore
 jetty.truststore.path=${openhab.userdata}/etc/keystore


### PR DESCRIPTION
With the changes in https://github.com/openhab/openhab-distro/pull/1079 the `ConfigDispatcher` looks for `services.cfg` in the current working dir which is `/userdata` (KARAF_DATA env var) and not `/runtime` (see [code](https://github.com/openhab/openhab-core/blob/d8fce0b8b31aa72ee107e04223d6e5a016ce54c3/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcher.java#L220-L227)).

As a result it cannot find `services.cfg`:

```
[ig.dispatch.internal.ConfigDispatcher] - Could not process default config file 'services.cfg': services.cfg (No such file or directory)
```

This causes the `FolderObserver` to be not initialized so items/things files cannot be used.
See also this [community topic](https://community.openhab.org/t/are-openhab-3-0-bindings-working/94812?u=wborn)