### PR TITLE
Configure felix.cm.dir so configurations are persisted (2.5.x)

### DIFF
--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -74,6 +74,7 @@ feature.openhab-model-runtime-all: \
 	bnd.identity;id='org.apache.servicemix.specs.jaxb-api-2.2'
 
 -runproperties: \
+	felix.cm.dir=${.}/runtime/userdata/config,\
 	log4j.configuration=file:${.}/runtime/log4j.xml,\
 	logback.configurationFile=file:${.}/runtime/logback.xml,\
 	org.osgi.framework.bootdelegation="sun.misc",\


### PR DESCRIPTION
After restarting the Demo App configurations are lost unless they are persisted by setting the `felix.cm.dir`. It will now store these in `/userdata/config` (similar to Karaf).

See also the [community](https://community.openhab.org/t/missing-dependancy-running-the-demo-app-in-eclipse/95463/34?u=wborn).