### PR TITLE
Migrate to JAX-RS Whiteboard

### DIFF
--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -59,7 +59,7 @@ feature.openhab-model-runtime-all: \
 	bnd.identity;id='org.openhab.core.automation.rest',\
 	bnd.identity;id='org.openhab.core.io.console.rfc147',\
 	bnd.identity;id='org.openhab.core.io.rest.sitemap',\
-	bnd.identity;id='org.openhab.core.io.rest.swagger1',\
+	bnd.identity;id='org.openhab.core.io.rest.swagger',\
 	bnd.identity;id='org.openhab.core.io.rest.ui',\
 	bnd.identity;id='org.openhab.ui',\
 	bnd.identity;id='org.openhab.ui.basic',\
@@ -216,7 +216,7 @@ feature.openhab-model-runtime-all: \
 	org.openhab.core.io.rest.core;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.rest.sitemap;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.rest.sse;version='[3.0.0,3.0.1)',\
-	org.openhab.core.io.rest.swagger1;version='[3.0.0,3.0.1)',\
+	org.openhab.core.io.rest.swagger;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.rest.ui;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.rest;version='[3.0.0,3.0.1)',\
 	org.openhab.core.model.core;version='[3.0.0,3.0.1)',\

--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -27,6 +27,7 @@ feature.openhab-base: \
 	bnd.identity;id='org.openhab.core.io.monitor',\
 	bnd.identity;id='org.openhab.core.io.net',\
 	bnd.identity;id='org.openhab.core.io.rest',\
+	bnd.identity;id='org.openhab.core.io.rest.auth',\
 	bnd.identity;id='org.openhab.core.io.rest.core',\
 	bnd.identity;id='org.openhab.core.io.rest.sse',\
 	bnd.identity;id='org.openhab.core.scheduler',\
@@ -159,6 +160,7 @@ feature.openhab-model-runtime-all: \
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
+	org.bitbucket.b_c.jose4j;version='[0.7.0,0.7.1)',\
 	org.eclipse.emf.common;version='[2.12.0,2.12.1)',\
 	org.eclipse.emf.ecore;version='[2.12.0,2.12.1)',\
 	org.eclipse.emf.ecore.xmi;version='[2.12.0,2.12.1)',\
@@ -198,7 +200,6 @@ feature.openhab-model-runtime-all: \
 	org.openhab.core.automation.rest;version='[3.0.0,3.0.1)',\
 	org.openhab.core.automation;version='[3.0.0,3.0.1)',\
 	org.openhab.core.binding.xml;version='[3.0.0,3.0.1)',\
-	org.openhab.core.boot;version='[3.0.0,3.0.1)',\
 	org.openhab.core.config.core;version='[3.0.0,3.0.1)',\
 	org.openhab.core.config.discovery;version='[3.0.0,3.0.1)',\
 	org.openhab.core.config.dispatch;version='[3.0.0,3.0.1)',\
@@ -211,6 +212,7 @@ feature.openhab-model-runtime-all: \
 	org.openhab.core.io.http;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.monitor;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.net;version='[3.0.0,3.0.1)',\
+	org.openhab.core.io.rest.auth;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.rest.core;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.rest.sitemap;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.rest.sse;version='[3.0.0,3.0.1)',\

--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -12,32 +12,30 @@ feature.debug: \
 	osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.command)'
 
 feature.openhab-base: \
+	bnd.identity;id='org.openhab.core',\
+	bnd.identity;id='org.openhab.core.audio',\
+	bnd.identity;id='org.openhab.core.auth.jaas',\
+	bnd.identity;id='org.openhab.core.binding.xml',\
 	bnd.identity;id='org.openhab.core.config.core',\
 	bnd.identity;id='org.openhab.core.config.discovery',\
 	bnd.identity;id='org.openhab.core.config.dispatch',\
 	bnd.identity;id='org.openhab.core.config.xml',\
-	bnd.identity;id='org.openhab.core',\
-	bnd.identity;id='org.openhab.core.auth.jaas',\
-	bnd.identity;id='org.openhab.core.storage.mapdb',\
-	bnd.identity;id='org.openhab.core.binding.xml',\
 	bnd.identity;id='org.openhab.core.id',\
-	bnd.identity;id='org.openhab.core.semantics',\
+	bnd.identity;id='org.openhab.core.io.console',\
+	bnd.identity;id='org.openhab.core.io.http',\
+	bnd.identity;id='org.openhab.core.io.http.auth',\
+	bnd.identity;id='org.openhab.core.io.monitor',\
+	bnd.identity;id='org.openhab.core.io.net',\
+	bnd.identity;id='org.openhab.core.io.rest',\
+	bnd.identity;id='org.openhab.core.io.rest.core',\
+	bnd.identity;id='org.openhab.core.io.rest.sse',\
 	bnd.identity;id='org.openhab.core.scheduler',\
+	bnd.identity;id='org.openhab.core.semantics',\
+	bnd.identity;id='org.openhab.core.storage.mapdb',\
 	bnd.identity;id='org.openhab.core.thing',\
 	bnd.identity;id='org.openhab.core.thing.xml',\
 	bnd.identity;id='org.openhab.core.transform',\
-	bnd.identity;id='org.openhab.core.audio',\
-	bnd.identity;id='org.openhab.core.voice',\
-	bnd.identity;id='org.openhab.core.io.console',\
-	bnd.identity;id='org.openhab.core.io.monitor',\
-	bnd.identity;id='org.openhab.core.io.net',\
-	bnd.identity;id='org.openhab.core.io.http',\
-	bnd.identity;id='org.openhab.core.io.http.auth',\
-	bnd.identity;id='org.openhab.core.io.rest',\
-	bnd.identity;id='org.openhab.core.io.rest.auth',\
-	bnd.identity;id='org.openhab.core.io.rest.optimize',\
-	bnd.identity;id='org.openhab.core.io.rest.core',\
-	bnd.identity;id='org.openhab.core.io.rest.sse'
+	bnd.identity;id='org.openhab.core.voice'
 
 feature.openhab-model-runtime-all: \
 	bnd.identity;id='org.openhab.core.model.item.runtime',\
@@ -53,18 +51,22 @@ feature.openhab-model-runtime-all: \
 	${feature.debug},\
 	${feature.openhab-base},\
 	${feature.openhab-model-runtime-all},\
-	bnd.identity;id='org.openhab.core.io.console.rfc147',\
 	bnd.identity;id='org.openhab.core.automation',\
 	bnd.identity;id='org.openhab.core.automation.module.media',\
 	bnd.identity;id='org.openhab.core.automation.module.script',\
 	bnd.identity;id='org.openhab.core.automation.module.script.rulesupport',\
 	bnd.identity;id='org.openhab.core.automation.rest',\
+	bnd.identity;id='org.openhab.core.io.console.rfc147',\
 	bnd.identity;id='org.openhab.core.io.rest.sitemap',\
+	bnd.identity;id='org.openhab.core.io.rest.swagger1',\
 	bnd.identity;id='org.openhab.core.io.rest.ui',\
 	bnd.identity;id='org.openhab.ui',\
 	bnd.identity;id='org.openhab.ui.basic',\
 	bnd.identity;id='org.openhab.ui.iconset.classic',\
-	bnd.identity;id='org.openhab.ui.restdocs'
+	bnd.identity;id='org.openhab.ui.restdocs',\
+	bnd.identity;id='org.apache.aries.jax.rs.whiteboard',\
+	bnd.identity;id='org.ops4j.pax.web.pax-web-extender-whiteboard',\
+	bnd.identity;id='jaxrswb-swagger1-gen'
 
 -runfw: org.eclipse.osgi
 
@@ -89,7 +91,6 @@ feature.openhab-model-runtime-all: \
 	openhab.userdata=${.}/runtime/userdata
 
 -runblacklist: \
-	bnd.identity;id='org.apache.aries.javax.jax.rs-api',\
 	bnd.identity;id='org.apache.aries.jpa.container',\
 	bnd.identity;id='org.openhab.core.test'
 
@@ -111,19 +112,32 @@ feature.openhab-model-runtime-all: \
 -runbundles: \
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	com.eclipsesource.jaxrs.jersey-all;version='[2.22.2,2.22.3)',\
-	com.eclipsesource.jaxrs.publisher;version='[5.3.1,5.3.2)',\
+	com.fasterxml.jackson.core.jackson-annotations;version='[2.10.3,2.10.4)',\
+	com.fasterxml.jackson.core.jackson-core;version='[2.10.3,2.10.4)',\
+	com.fasterxml.jackson.core.jackson-databind;version='[2.10.3,2.10.4)',\
+	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.10.3,2.10.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
 	com.google.guava;version='[27.1.0,27.1.1)',\
 	com.google.inject;version='[3.0.0,3.0.1)',\
 	io.github.classgraph;version='[4.8.35,4.8.36)',\
+	io.swagger.annotations;version='[1.6.1,1.6.2)',\
+	io.swagger.core;version='[1.6.1,1.6.2)',\
+	io.swagger.jaxrs;version='[1.6.1,1.6.2)',\
+	io.swagger.models;version='[1.6.1,1.6.2)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
+	javax.validation.api;version='[1.1.0,1.1.1)',\
+	javax.xml.soap-api;version='[1.3.5,1.3.6)',\
+	jaxb-api;version='[2.2.11,2.2.12)',\
+	jaxrswb-swagger1-gen;version='[0.0.4,0.0.5)',\
 	jollyday;version='[0.5.8,0.5.9)',\
 	log4j;version='[1.2.17,1.2.18)',\
 	org.antlr.runtime;version='[3.2.0,3.2.1)',\
+	org.apache.aries.javax.jax.rs-api;version='[1.0.0,1.0.1)',\
+	org.apache.aries.jax.rs.whiteboard;version='[1.0.5,1.0.6)',\
 	org.apache.commons.fileupload;version='[1.3.3,1.3.4)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
+	org.apache.commons.lang3;version='[3.9.0,3.9.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.felix.gogo.command;version='[1.0.2,1.0.3)',\
@@ -140,6 +154,7 @@ feature.openhab-model-runtime-all: \
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
+	org.apache.servicemix.specs.jaxws-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
@@ -169,17 +184,20 @@ feature.openhab-model-runtime-all: \
 	org.eclipse.xtext.xbase.lib;version='[2.19.0,2.19.1)',\
 	org.eclipse.xtext.xbase;version='[2.19.0,2.19.1)',\
 	org.glassfish.hk2.external.aopalliance-repackaged;version='[2.4.0,2.4.1)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
 	org.mapdb.mapdb;version='[1.0.9,1.0.10)',\
 	org.objectweb.asm.commons;version='[7.1.0,7.1.1)',\
 	org.objectweb.asm.tree;version='[7.1.0,7.1.1)',\
 	org.objectweb.asm;version='[7.1.0,7.1.1)',\
 	org.openhab.core.audio;version='[3.0.0,3.0.1)',\
+	org.openhab.core.auth.jaas;version='[3.0.0,3.0.1)',\
 	org.openhab.core.automation.module.media;version='[3.0.0,3.0.1)',\
 	org.openhab.core.automation.module.script.rulesupport;version='[3.0.0,3.0.1)',\
 	org.openhab.core.automation.module.script;version='[3.0.0,3.0.1)',\
 	org.openhab.core.automation.rest;version='[3.0.0,3.0.1)',\
 	org.openhab.core.automation;version='[3.0.0,3.0.1)',\
 	org.openhab.core.binding.xml;version='[3.0.0,3.0.1)',\
+	org.openhab.core.boot;version='[3.0.0,3.0.1)',\
 	org.openhab.core.config.core;version='[3.0.0,3.0.1)',\
 	org.openhab.core.config.discovery;version='[3.0.0,3.0.1)',\
 	org.openhab.core.config.dispatch;version='[3.0.0,3.0.1)',\
@@ -188,13 +206,14 @@ feature.openhab-model-runtime-all: \
 	org.openhab.core.id;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.console.rfc147;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.console;version='[3.0.0,3.0.1)',\
+	org.openhab.core.io.http.auth;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.http;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.monitor;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.net;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.rest.core;version='[3.0.0,3.0.1)',\
-	org.openhab.core.io.rest.optimize;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.rest.sitemap;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.rest.sse;version='[3.0.0,3.0.1)',\
+	org.openhab.core.io.rest.swagger1;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.rest.ui;version='[3.0.0,3.0.1)',\
 	org.openhab.core.io.rest;version='[3.0.0,3.0.1)',\
 	org.openhab.core.model.core;version='[3.0.0,3.0.1)',\
@@ -227,18 +246,19 @@ feature.openhab-model-runtime-all: \
 	org.openhab.ui;version='[3.0.0,3.0.1)',\
 	org.ops4j.pax.swissbox.optional.jcl;version='[1.8.3,1.8.4)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.11,7.2.12)',\
+	org.ops4j.pax.web.pax-web-extender-whiteboard;version='[7.2.11,7.2.12)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.11,7.2.12)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.11,7.2.12)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.11,7.2.12)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
+	org.osgi.service.jaxrs;version='[1.0.0,1.0.1)',\
 	org.osgi.service.metatype;version='[1.4.0,1.4.1)',\
+	org.osgi.util.function;version='[1.1.0,1.1.1)',\
+	org.osgi.util.promise;version='[1.1.0,1.1.1)',\
 	org.threeten.extra;version='[1.4.0,1.4.1)',\
+	org.yaml.snakeyaml;version='[1.24.0,1.24.1)',\
+	reflections;version='[0.9.10,0.9.11)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	slf4j.simple;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
-	org.bitbucket.b_c.jose4j;version='[0.7.0,0.7.1)',\
-	org.openhab.core.auth.jaas;version='[3.0.0,3.0.1)',\
-	org.openhab.core.io.rest.auth;version='[3.0.0,3.0.1)',\
-	org.openhab.core.io.http.auth;version='[3.0.0,3.0.1)'
-
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -135,7 +135,7 @@ feature.openhab-model-runtime-all: \
 	log4j;version='[1.2.17,1.2.18)',\
 	org.antlr.runtime;version='[3.2.0,3.2.1)',\
 	org.apache.aries.javax.jax.rs-api;version='[1.0.0,1.0.1)',\
-	org.apache.aries.jax.rs.whiteboard;version='[1.0.5,1.0.6)',\
+	org.apache.aries.jax.rs.whiteboard;version='[1.0.8,1.0.9)',\
 	org.apache.commons.fileupload;version='[1.3.3,1.3.4)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang3;version='[3.9.0,3.9.1)',\

--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -92,7 +92,8 @@ feature.openhab-model-runtime-all: \
 
 -runblacklist: \
 	bnd.identity;id='org.apache.aries.jpa.container',\
-	bnd.identity;id='org.openhab.core.test'
+	bnd.identity;id='org.openhab.core.test',\
+	bnd.identity;id='slf4j.simple'
 
 -runvm.java9plus: \
 	--add-opens java.base/java.io=ALL-UNNAMED,\
@@ -145,7 +146,7 @@ feature.openhab-model-runtime-all: \
 	org.apache.felix.gogo.shell;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.inventory;version='[1.0.4,1.0.5)',\
-	org.apache.felix.logback;version='[1.0.0,1.0.1)',\
+	org.apache.felix.logback;version='[1.0.2,1.0.3)',\
 	org.apache.felix.log;version='[1.2.0,1.2.1)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
 	org.apache.felix.webconsole.plugins.ds;version='[2.0.8,2.0.9)',\
@@ -259,6 +260,5 @@ feature.openhab-model-runtime-all: \
 	org.yaml.snakeyaml;version='[1.24.0,1.24.1)',\
 	reflections;version='[0.9.10,0.9.11)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/launch/app/runtime/services.cfg
+++ b/launch/app/runtime/services.cfg
@@ -10,10 +10,6 @@ org.openhab.basicui:enableIcons=true
 org.openhab.basicui:condensedLayout=false
 org.openhab.basicui:capitalizeValues=false
 
-org.jupnp:threadPoolSize=20
-
-de.maggu2810.jaxrswb.swagger1.gen:info.title=openHAB REST API
-
 # Uncomment to enable rest api CORS requests
 # org.openhab.cors:enable=true
 
@@ -21,3 +17,11 @@ de.maggu2810.jaxrswb.swagger1.gen:info.title=openHAB REST API
 org.openhab.threadpool:thingHandler=3
 org.openhab.threadpool:discovery=3
 org.openhab.threadpool:safeCall=3
+
+de.maggu2810.jaxrswb.swagger1.gen:info.title=openHAB REST API
+
+org.apache.aries.jax.rs.whiteboard.default:default.web=false
+org.apache.aries.jax.rs.whiteboard.default:default.application.base=/jax-rs-whiteboard-default
+org.apache.aries.jax.rs.whiteboard.default:replace.loopback.address.with.localhost=false
+
+org.jupnp:threadPoolSize=20

--- a/launch/app/runtime/services.cfg
+++ b/launch/app/runtime/services.cfg
@@ -20,8 +20,6 @@ org.openhab.threadpool:safeCall=3
 
 de.maggu2810.jaxrswb.swagger1.gen:info.title=openHAB REST API
 
-org.apache.aries.jax.rs.whiteboard.default:default.web=false
-org.apache.aries.jax.rs.whiteboard.default:default.application.base=/jax-rs-whiteboard-default
 org.apache.aries.jax.rs.whiteboard.default:replace.loopback.address.with.localhost=false
 
 org.jupnp:threadPoolSize=20

--- a/launch/app/runtime/services.cfg
+++ b/launch/app/runtime/services.cfg
@@ -12,11 +12,7 @@ org.openhab.basicui:capitalizeValues=false
 
 org.jupnp:threadPoolSize=20
 
-# Set the rest api to be under /rest
-com.eclipsesource.jaxrs.connector:root=/rest
-com.eclipsesource.jaxrs.swagger.config:swagger.basePath=/rest
-com.eclipsesource.jaxrs.swagger.config:swagger.info.title=openHAB REST API
-com.eclipsesource.jaxrs.swagger.config:swagger.info.version=1.0
+de.maggu2810.jaxrswb.swagger1.gen:info.title=openHAB REST API
 
 # Uncomment to enable rest api CORS requests
 # org.openhab.cors:enable=true


### PR DESCRIPTION
When `de.maggu2810.thirdparty.modified.org.reflections` is used as runtime dependency, the Swagger bundles resolve properly because it has an optional dependency on `com.google.common.base` .
So now `/rest/swagger.json` is also generated and the REST Docs UI will properly work. :slightly_smiling_face: 

Fixes #945
Fixes #1045

Depends on https://github.com/openhab/openhab-core/pull/1443