### PR TITLE
Remove the restdocs UI and jaxrswb-swagger1-gen from the demo app

### DIFF
--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -64,10 +64,8 @@ feature.openhab-model-runtime-all: \
 	bnd.identity;id='org.openhab.ui',\
 	bnd.identity;id='org.openhab.ui.basic',\
 	bnd.identity;id='org.openhab.ui.iconset.classic',\
-	bnd.identity;id='org.openhab.ui.restdocs',\
 	bnd.identity;id='org.apache.aries.jax.rs.whiteboard',\
-	bnd.identity;id='org.ops4j.pax.web.pax-web-extender-whiteboard',\
-	bnd.identity;id='jaxrswb-swagger1-gen'
+	bnd.identity;id='org.ops4j.pax.web.pax-web-extender-whiteboard'
 
 -runfw: org.eclipse.osgi
 
@@ -130,8 +128,6 @@ feature.openhab-model-runtime-all: \
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	javax.validation.api;version='[1.1.0,1.1.1)',\
 	javax.xml.soap-api;version='[1.3.5,1.3.6)',\
-	jaxb-api;version='[2.2.11,2.2.12)',\
-	jaxrswb-swagger1-gen;version='[0.0.4,0.0.5)',\
 	jollyday;version='[0.5.8,0.5.9)',\
 	log4j;version='[1.2.17,1.2.18)',\
 	org.antlr.runtime;version='[3.2.0,3.2.1)',\
@@ -244,7 +240,6 @@ feature.openhab-model-runtime-all: \
 	org.openhab.core.voice;version='[3.0.0,3.0.1)',\
 	org.openhab.ui.basic;version='[3.0.0,3.0.1)',\
 	org.openhab.ui.iconset.classic;version='[3.0.0,3.0.1)',\
-	org.openhab.ui.restdocs;version='[3.0.0,3.0.1)',\
 	org.openhab.ui;version='[3.0.0,3.0.1)',\
 	org.ops4j.pax.swissbox.optional.jcl;version='[1.8.3,1.8.4)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.11,7.2.12)',\
@@ -259,7 +254,9 @@ feature.openhab-model-runtime-all: \
 	org.osgi.util.promise;version='[1.1.0,1.1.1)',\
 	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	org.yaml.snakeyaml;version='[1.24.0,1.24.1)',\
-	reflections;version='[0.9.10,0.9.11)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	jakarta.xml.bind-api;version='[2.3.2,2.3.3)',\
+	javassist;version='[3.26.0,3.26.1)',\
+	org.reflections;version='[0.9.12,0.9.13)'


### PR DESCRIPTION
Related to https://github.com/openhab/openhab-core/pull/1496 & https://github.com/openhab/openhab-webui/pull/297

Signed-off-by: Yannick Schaus <github@schaus.net>