### PR TITLE
Disable ZWave feature

### DIFF
--- a/features/addons/src/main/feature/feature.xml
+++ b/features/addons/src/main/feature/feature.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
-    
+
     <!-- these are add-ons in separate repositories (which do not have their own Karaf feature defined), so we include them here -->
-    
+
     <!-- TODO: This is disabled until a working zigbee binding is available on the zigbee repo master branch
     <feature name="openhab-binding-zigbee" description="ZigBee Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
@@ -19,11 +19,13 @@
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zigbee.xbee/${project.version}</bundle>
     </feature>
      -->
-     
+
+    <!-- TODO: This is disabled until a working zwave binding is available on the zwave repo master branch
     <feature name="openhab-binding-zwave" description="Z-Wave Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-serial</feature>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zwave/${project.version}</bundle>
     </feature>
-    
+     -->
+
 </features>


### PR DESCRIPTION
The ZWave master branch no longer compiles but the distro is still including an OH3 incompatible bundle in the feature.

---

As more users are now testing OH3 we don't want them to [waste their precious time](https://community.openhab.org/t/wiki-getting-started-with-oh3-rewriting-the-tutorial-1-introduction/100982/50?u=wborn) on add-ons that are known not to work.

CC: @cdjackson 