### PR TITLE
Switched back to single add-ons feature file 

### DIFF
--- a/distributions/openhab-addons/pom.xml
+++ b/distributions/openhab-addons/pom.xml
@@ -24,14 +24,7 @@
         <dependency>
             <groupId>org.openhab.addons.features.karaf</groupId>
             <artifactId>org.openhab.addons.features.karaf.openhab-addons</artifactId>
-            <version>${oh2.version}</version>
-            <classifier>features</classifier>
-            <type>xml</type>
-        </dependency>
-        <dependency>
-            <groupId>org.openhab.addons.features.karaf</groupId>
-            <artifactId>org.openhab.addons.features.karaf.openhab-addons3</artifactId>
-            <version>${oh2.version}</version>
+            <version>${project.version}</version>
             <classifier>features</classifier>
             <type>xml</type>
         </dependency>

--- a/features/addons/pom.xml
+++ b/features/addons/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>feature</packaging>
 
 	<name>openHAB Add-ons</name>
-	<description>These are 2.x add-ons in separate repositories (which do not have their own Karaf feature defined).</description>
+	<description>These are add-ons in separate repositories (which do not have their own Karaf feature defined).</description>
 
 	<build>
 		<plugins>

--- a/features/addons/src/main/feature/feature.xml
+++ b/features/addons/src/main/feature/feature.xml
@@ -20,12 +20,10 @@
     </feature>
      -->
 
-    <!-- TODO: This is disabled until a working zwave binding is available on the zwave repo master branch
     <feature name="openhab-binding-zwave" description="Z-Wave Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-serial</feature>
         <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.zwave/${project.version}</bundle>
     </feature>
-     -->
 
 </features>


### PR DESCRIPTION
(no need to combine 2.5.x and 3.x build results anymore)

Related to https://github.com/openhab/openhab-addons/pull/8532.

Also re-added Z-Wave to the distro.

Signed-off-by: Kai Kreuzer <kai@openhab.org>