### PR TITLE
Update bndtools update site

### DIFF
--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2357,7 +2357,7 @@
       <requirement
           name="bjmi.m2e.sourcelookup.feature.feature.group"/>
       <repository
-          url="https://dl.bintray.com/bndtools/bndtools/latest/"/>
+          url="https://bndtools.jfrog.io/bndtools/update-latest/"/>
       <repository
           url="https://bjmi.github.io/update-site/"/>
     </setupTask>


### PR DESCRIPTION
A newer bndtools version is necessary when using JUnit 5.
The bintray site only has 4.3.1 while the jfrog site has many more including 5.1.2.

See: https://bndtools.org/installation.html