### PR TITLE
Remove storage configuration migration from OH3 update

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -86,11 +86,6 @@ REPLACE;org.eclipse.smarthome.network;org.openhab.network;$OPENHAB_USERDATA/conf
 MOVE;$OPENHAB_USERDATA/config/org/eclipse/smarthome/rulehli.config;$OPENHAB_USERDATA/config/org/openhab/rulehli.config
 REPLACE;org.eclipse.smarthome.rulehli;org.openhab.rulehli;$OPENHAB_USERDATA/config/org/openhab/rulehli.config
 
-MOVE;$OPENHAB_USERDATA/config/org/eclipse/smarthome/storage/json.config;$OPENHAB_USERDATA/config/org/openhab/storage/json.config
-REPLACE;org.eclipse.smarthome.storage.json;org.openhab.storage.json;$OPENHAB_USERDATA/config/org/openhab/storage/json.config
-MOVE;$OPENHAB_USERDATA/config/org/eclipse/smarthome/storage/mapdb.config;$OPENHAB_USERDATA/config/org/openhab/storage/mapdb.config
-REPLACE;org.eclipse.smarthome.storage.mapdb;org.openhab.storage.mapdb;$OPENHAB_USERDATA/config/org/openhab/storage/json.config
-
 REPLACE;org.eclipse.smarthome.core;org.openhab.core;$OPENHAB_USERDATA/jsondb/automation_rules.json
 REPLACE;org.eclipse.smarthome;org.openhab.core;$OPENHAB_USERDATA/jsondb/automation_rules.json
 


### PR DESCRIPTION
* The storage dir does not exist causing errors when the commands are executed and there is no command to create the dir
* The mapdb storage no longer exists so it should not be migrated

See also this [community topic](https://community.openhab.org/t/guide-installing-and-testing-oh3-snapshots-using-apt-and-yum/104572/54?u=wborn)