### PR TITLE
Filter CXF SseEventSinkImpl warnings

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/log4j2.xml
+++ b/distributions/openhab/src/main/resources/userdata/etc/log4j2.xml
@@ -90,6 +90,9 @@
 		<!-- Can be removed once the issues are resolved in an upcoming version. -->
 		<Logger level="OFF" name="org.eclipse.lsp4j"/>
 
+		<!-- Filters warnings for events that could not be delivered to a disconnected client. -->
+		<Logger level="ERROR" name="org.apache.cxf.jaxrs.sse.SseEventSinkImpl"/>
+
 		<!-- Filters known issues of KarServiceImpl, see -->
 		<!-- https://github.com/openhab/openhab-distro/issues/519#issuecomment-351944506 -->
 		<!-- Can be removed once the issues are resolved in an upcoming version. -->


### PR DESCRIPTION
Filters the "There are still SSE events the queue which may not be delivered (closing now)" warnings logged by the CXF SseEventSinkImpl.
It often logs these whenever events could not be delivered to a UI that recently closed its SSE stream.