### PR TITLE
set default logging to debug for bindings

### DIFF
--- a/launch/app/runtime/logback.xml
+++ b/launch/app/runtime/logback.xml
@@ -39,5 +39,7 @@
   </root>
 
   <logger name="org.openhab.core" level="INFO" />
+  <logger name="org.openhab.core" level="DEBUG" />
+
 
 </configuration>


### PR DESCRIPTION
As in the demo environment we typically use for testing, bindings can be more verbose

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>