### PR TITLE
Removed runtime config of auto-linking feature

### DIFF
--- a/distributions/openhab/src/main/resources/conf/services/runtime.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/runtime.cfg
@@ -77,10 +77,3 @@ org.openhab.ephemeris:dayset-school=[MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY]
 # so that they are immediately available in the system (default is false)
 #
 #org.openhab.inbox:autoApprove=true
-
-# This setting allows to switch between a "simple" and an "advanced" mode for item management.
-# In simple mode (autoLinks=true), links and their according items are automatically created for new Things.
-# In advanced mode (autoLinks=false), the user has the full control about which items channels are linked to.
-# Existing links will remain untouched. (default is true)
-#
-#org.openhab.links:autoLinks=false


### PR DESCRIPTION
- Removed runtime config of auto-linking feature

Has been removed in https://github.com/openhab/openhab-core/pull/1385

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>