### PR TITLE
Disable periodic logging of performance data by the JVM

### DIFF
--- a/distributions/openhab/src/main/resources/bin/setenv
+++ b/distributions/openhab/src/main/resources/bin/setenv
@@ -117,7 +117,7 @@ export JAVA_OPTS="${JAVA_OPTS}
 # set JVM options
 #
 ARCH=`uname -m`
-EXTRA_JAVA_OPTS_COMMON="-Djava.awt.headless=true"
+EXTRA_JAVA_OPTS_COMMON="-Djava.awt.headless=true -XX:-UsePerfData"
 EXTRA_JAVA_OPTS_ARCH=""
 case "$ARCH" in
     *arm*) ;;

--- a/distributions/openhab/src/main/resources/bin/setenv.bat
+++ b/distributions/openhab/src/main/resources/bin/setenv.bat
@@ -134,6 +134,7 @@ set JAVA_OPTS=%JAVA_OPTS% ^
 
 :: set jvm options
 set EXTRA_JAVA_OPTS=-XX:+UseG1GC ^
+  -XX:-UsePerfData ^
   -Djava.awt.headless=true ^
   -Dfile.encoding=UTF-8 ^
   %EXTRA_JAVA_OPTS%


### PR DESCRIPTION
Many JVMs log performance data to /tmp/hsperfdata_openhab/[pid] every 30s. This wears SD cards and prevents HDDs from spinning down. Closes #847

I came to this because the default JDK of Raspbian on my raspi has above behavior.

Signed-off-by: Fabian Wolter <github@fabian-wolter.de>