### PR TITLE
Create directory if necessary before moving file

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update
+++ b/distributions/openhab/src/main/resources/bin/update
@@ -166,6 +166,13 @@ runCommand() {
     ;;
     'MOVE')
       echo "  Moving:   From $param1 to $param2"
+      fileDir=$(dirname "$param2")
+      # Create directory with same ownership as file
+      if [ ! -d fileDir ]; then
+        mkdir -p "$fileDir"
+        prevUserGroup=$(ls -ld "$param1" | awk '{print $3 ":" $4}')
+        chown -R "$prevUserGroup" "$fileDir"
+      fi
       mv "$param1" "$param2"
     ;;
     'REPLACE')


### PR DESCRIPTION
Necessary for commands such as:

```
MOVE;$OPENHAB_USERDATA/config/org/eclipse/smarthome/autoupdate.config;$OPENHAB_USERDATA/config/org/openhab/autoupdate.config
```
where `config/org/openhab` might not exist yet.

Please could someone test upgrade from OH2 to OH3 using this, and again on macOS?

Signed-off-by: Ben Clark <ben@benjyc.uk>