### PR TITLE
Remove custom mdnsName configuration

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/custom.system.properties
+++ b/distributions/openhab/src/main/resources/userdata/etc/custom.system.properties
@@ -1,6 +1,5 @@
 karaf.name=openhab
 karaf.local.user=openhab
-mdnsName=openhab
 openhab.servicecfg=${openhab.runtime}/services.cfg
 jetty.keystore.path=${openhab.userdata}/etc/keystore
 jetty.truststore.path=${openhab.userdata}/etc/keystore


### PR DESCRIPTION
This customization is no longer necessary when https://github.com/openhab/openhab-core/pull/1901 is merged.