### PR TITLE
Removed org.openhab prefix and added start level definitions

### DIFF
--- a/distributions/openhab/src/main/resources/runtime/services.cfg
+++ b/distributions/openhab/src/main/resources/runtime/services.cfg
@@ -1,16 +1,24 @@
 # This file defines required service configurations.
 # It can be overridden by user specific configurations in conf/services folder.
 
-org.openhab.folder:items=items
-org.openhab.folder:sitemaps=sitemap
-org.openhab.folder:rules=rules
-org.openhab.folder:scripts=script
-org.openhab.folder:persistence=persist
-org.openhab.folder:things=things
+folder:items=items
+folder:sitemaps=sitemap
+folder:rules=rules
+folder:scripts=script
+folder:persistence=persist
+folder:things=things
 
 # Configuration of thread pool sizes
-org.openhab.threadpool:thingHandler=5
-org.openhab.threadpool:discovery=5
-org.openhab.threadpool:safeCall=10
+threadpool:discovery=5
+threadpool:safeCall=10
+threadpool:thingHandler=5
 
+# Start level definitions
+startlevel:20=dsl:items,managed:item,dsl:things,managed:thing,managed:itemchannellink,dsl:persist
+startlevel:30=persistence:restore
+startlevel:40=dsl:rules,managed:rule,rules:refresh,rules:dslprovider
+startlevel:50=ruleengine:start
+startlevel:70=dsl:sitemap
+
+# Auto-update event behavior
 org.openhab.autoupdate:sendOptimisticUpdates=true

--- a/launch/app/runtime/services.cfg
+++ b/launch/app/runtime/services.cfg
@@ -1,23 +1,30 @@
-org.openhab.folder:items=items
-org.openhab.folder:sitemaps=sitemap
-org.openhab.folder:rules=rules
-org.openhab.folder:scripts=script
-org.openhab.folder:persistence=persist
-org.openhab.folder:things=things
+folder:items=items
+folder:sitemaps=sitemap
+folder:rules=rules
+folder:scripts=script
+folder:persistence=persist
+folder:things=things
 
-org.openhab.basicui:defaultSitemap=demo
-org.openhab.basicui:enableIcons=true
-org.openhab.basicui:condensedLayout=false
-org.openhab.basicui:capitalizeValues=false
+basicui:defaultSitemap=demo
+basicui:enableIcons=true
+basicui:condensedLayout=false
+basicui:capitalizeValues=false
 
 # Uncomment to enable rest api CORS requests
-# org.openhab.cors:enable=true
+# cors:enable=true
 
 # Configuration of thread pool sizes
-org.openhab.threadpool:thingHandler=3
-org.openhab.threadpool:discovery=3
-org.openhab.threadpool:safeCall=3
+threadpool:thingHandler=3
+threadpool:discovery=3
+threadpool:safeCall=3
 
 org.apache.aries.jax.rs.whiteboard.default:replace.loopback.address.with.localhost=false
 
 org.jupnp:threadPoolSize=20
+
+# Start level definition
+startlevel:20=dsl:items,managed:item,dsl:things,managed:thing,managed:itemchannellink,dsl:persist
+#startlevel:30=persistence:restore // do not rely on the presence of a persistence service in the IDE
+startlevel:40=dsl:rules,managed:rule,rules:refresh,rules:dslprovider
+startlevel:50=ruleengine:start
+startlevel:70=dsl:sitemap


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-core/pull/1914

Signed-off-by: Kai Kreuzer <kai@openhab.org>