### PR TITLE
Use default logging configuration after update

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -118,3 +118,6 @@ DELETEDIR;$OPENHAB_USERDATA/habmin
 DELETE;$OPENHAB_USERDATA/etc/com.eclipsesource.jaxrs.connector.cfg	
 DELETE;$OPENHAB_USERDATA/etc/com.eclipsesource.jaxrs.swagger.cfg
 DELETEDIR;$OPENHAB_USERDATA/config/com/eclipsesource
+
+DEFAULT;$OPENHAB_USERDATA/etc/log4j2.xml
+DEFAULT;$OPENHAB_USERDATA/etc/org.ops4j.pax.logging.cfg


### PR DESCRIPTION
Adds DEFAULT instructions for:

* log4j2.xml
* org.ops4j.pax.logging.cfg

---

See: https://github.com/openhab/openhab-distro/pull/1206#issuecomment-745427684