### PR TITLE
Rollover log files on startup

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/log4j2.xml
+++ b/distributions/openhab/src/main/resources/userdata/etc/log4j2.xml
@@ -10,6 +10,7 @@
 		<RollingFile fileName="${sys:openhab.logdir}/openhab.log" filePattern="${sys:openhab.logdir}/openhab.log.%i" name="LOGFILE">
 			<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5.5p] [%-36.36c] - %m%n"/>
 			<Policies>
+				<OnStartupTriggeringPolicy/>
 				<SizeBasedTriggeringPolicy size="16 MB"/>
 			</Policies>
 		</RollingFile>
@@ -18,6 +19,7 @@
 		<RollingRandomAccessFile fileName="${sys:openhab.logdir}/events.log" filePattern="${sys:openhab.logdir}/events.log.%i" name="EVENT">
 			<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5.5p] [%-36.36c] - %m%n"/>
 			<Policies>
+				<OnStartupTriggeringPolicy/>
 				<SizeBasedTriggeringPolicy size="16 MB"/>
 			</Policies>
 		</RollingRandomAccessFile>
@@ -26,6 +28,7 @@
 		<RollingRandomAccessFile fileName="${sys:openhab.logdir}/audit.log" filePattern="${sys:openhab.logdir}/audit.log.%i" name="AUDIT">
 			<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5.5p] [%-36.36c] - %m%n"/>
 			<Policies>
+				<OnStartupTriggeringPolicy/>
 				<SizeBasedTriggeringPolicy size="8 MB"/>
 			</Policies>
 		</RollingRandomAccessFile>


### PR DESCRIPTION
This is something that I use for my setup, as it makes investigating log files much easier because they are rollled over on startup. This means, you really start with a "clean" log file when you restart openHAB. I used to do the rollover manually in the past as I didn't had the idea that it's configurable via log4j, and probably many users often do so as well.

First, I wanted to put it in the docs, but then I thought: Why not using it as default? I think the majority of users will like it more than the current default.

Signed-off-by: Patrick Fink <mail@pfink.de>