### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# This file helps GitHub doing automatic review requests for new PRs.
+# It should always list the active maintainers of the distro.
+
+# Assign all PRs to the distro maintainers:
+*       @openhab/distro-maintainers


### PR DESCRIPTION
With a CODEOWNERS file we don't have to manually request reviews, so it prevents some clicking and may help speed up reviews and prevent duplicate PRs.