### PR TITLE
Automatically build Docker images for new releases

### DIFF
--- a/launch/Jenkinsfile
+++ b/launch/Jenkinsfile
@@ -36,6 +36,10 @@ try {
         deleteDir()
         releaseComponent('openhab-distro', true, "master")
     }
+
+    if(!env.SANDBOX?.toBoolean()) {
+        build wait: false, job: 'openHAB-Docker', parameters: [string(name: 'OPENHAB_VERSION', value: "$OH_RELEASE_VERSION")]
+    }
 }
 catch(Exception e) {
     notifyFailedOpenhabBuild()


### PR DESCRIPTION
Trigger the openHAB-Docker build after a new distribution has been released.