### PR TITLE
Monitor log4j2.xml for changes

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/log4j2.xml
+++ b/distributions/openhab/src/main/resources/userdata/etc/log4j2.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><Configuration>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><Configuration monitorInterval="10">
 
 	<Appenders>
 		<!-- Console appender not used by default (see Root logger AppenderRefs) -->


### PR DESCRIPTION
Fixes #1187

We might want to reset the logging config again. If we do that now it will reset everyones logging configuration again everytime they update from one snapshot to another. But if we don't do it now it will also not fix the issue immediately. :-/