### PR TITLE
Filter ChromeCast Java API disconnection warnings

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/log4j2.xml
+++ b/distributions/openhab/src/main/resources/userdata/etc/log4j2.xml
@@ -113,6 +113,10 @@
 		<!-- https://github.com/openhab/openhab-addons/issues/5530 -->
 		<Logger level="ERROR" name="javax.mail"/>
 
+		<!-- Filters disconnection warnings of the ChromeCast Java API, see -->
+		<!-- https://github.com/openhab/openhab-addons/issues/3770 -->
+		<Logger level="ERROR" name="su.litvak.chromecast.api.v2.Channel"/>
+
 		<!-- Added by Karaf to prevent debug logging loops, see -->
 		<!-- https://issues.apache.org/jira/browse/KARAF-5559 -->
 		<Logger level="WARN" name="org.apache.sshd"/>


### PR DESCRIPTION
Disconnections from devices are expected and should not generate warnings in the logging.

See also openhab/openhab-addons#3770

Fixes #1241