### PR TITLE
Suppress illegal reflective access operation warnings for java.time

### DIFF
--- a/distributions/openhab/src/main/resources/bin/karaf
+++ b/distributions/openhab/src/main/resources/bin/karaf
@@ -313,6 +313,7 @@ run() {
                     --add-opens java.base/java.io=ALL-UNNAMED \
                     --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
                     --add-opens java.base/java.text=ALL-UNNAMED \
+                    --add-opens java.base/java.time=ALL-UNNAMED \
                     --add-opens java.desktop/java.awt.font=ALL-UNNAMED \
                     --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED \
                     --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED \

--- a/distributions/openhab/src/main/resources/bin/karaf.bat
+++ b/distributions/openhab/src/main/resources/bin/karaf.bat
@@ -441,6 +441,7 @@ if "%KARAF_PROFILER%" == "" goto :RUN
                 --add-opens java.base/java.io=ALL-UNNAMED ^
                 --add-opens java.base/java.lang.reflect=ALL-UNNAMED ^
                 --add-opens java.base/java.text=ALL-UNNAMED ^
+                --add-opens java.base/java.time=ALL-UNNAMED ^
                 --add-opens java.desktop/java.awt.font=ALL-UNNAMED ^
                 --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED ^
                 --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED ^

--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -100,6 +100,7 @@ feature.openhab-model-runtime-all: \
 	--add-opens=java.base/java.net=ALL-UNNAMED,\
 	--add-opens=java.base/java.security=ALL-UNNAMED,\
 	--add-opens=java.base/java.text=ALL-UNNAMED,\
+	--add-opens=java.base/java.time=ALL-UNNAMED,\
 	--add-opens=java.base/java.util=ALL-UNNAMED,\
 	--add-opens=java.desktop/java.awt.font=ALL-UNNAMED,\
 	--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED,\


### PR DESCRIPTION
Suppresses the following warnings when the tokens of the OHC OAuth2 client are (de)serialized by the JSON Storage:

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.gson.internal.bind.ReflectiveTypeAdapterFactory (file:/openhab/userdata/cache/org.eclipse.osgi/27/0/bundleFile) to field java.time.LocalDateTime.date
WARNING: Please consider reporting this to the maintainers of com.google.gson.internal.bind.ReflectiveTypeAdapterFactory
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

Fixes https://github.com/openhab/openhab-addons/issues/9587