### PR TITLE
Removed Bintray and JFrog dependency from update url

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update
+++ b/distributions/openhab/src/main/resources/bin/update
@@ -95,11 +95,11 @@ setup(){
     echo "You are already on openHAB $CurrentVersion" >&2
     exit 1
   elif [ -n "$milestoneVersion" ]; then
-    DownloadLocation="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/$OHVersion/openhab-$OHVersion.zip"
-    AddonsDownloadLocation="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/$OHVersion/openhab-addons-$OHVersion.kar"
+    DownloadLocation="https://www.openhab.org/download/milestones/org/openhab/distro/openhab/$OHVersion/openhab-$OHVersion.zip"
+    AddonsDownloadLocation="https://www.openhab.org/download/milestones/org/openhab/distro/openhab-addons/$OHVersion/openhab-addons-$OHVersion.kar"
   else
-    DownloadLocation="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F$OHVersion%2Fopenhab-$OHVersion.zip"
-    AddonsDownloadLocation="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F$OHVersion%2Fopenhab-addons-$OHVersion.kar"
+    DownloadLocation="https://www.openhab.org/download/releases/org/openhab/distro/openhab/$OHVersion/openhab-$OHVersion.zip"
+    AddonsDownloadLocation="https://www.openhab.org/download/releases/org/openhab/distro/openhab-addons/$OHVersion/openhab-addons-$OHVersion.kar"
   fi
 
   ## Set the temporary directories.

--- a/distributions/openhab/src/main/resources/bin/update.ps1
+++ b/distributions/openhab/src/main/resources/bin/update.ps1
@@ -495,12 +495,12 @@ Function Update-openHAB() {
         $AddonsDownloadLocation="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-$OHVersionName.kar"
     }
     elseif ($Milestone -ne "") {
-        $DownloadLocation="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/$OHVersionName/openhab-$OHVersionName.zip"
-        $AddonsDownloadLocation="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/$OHVersionName/openhab-addons-$OHVersionName.kar"
+        $DownloadLocation="https://www.openhab.org/download/milestones/org/openhab/distro/openhab/$OHVersionName/openhab-$OHVersionName.zip"
+        $AddonsDownloadLocation="https://www.openhab.org/download/milestones/org/openhab/distro/openhab-addons/$OHVersionName/openhab-addons-$OHVersionName.kar"
     }
     else {
-        $DownloadLocation = "https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F$OHVersion%2Fopenhab-$OHVersion.zip"
-        $AddonsDownloadLocation = "https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F$OHVersion%2Fopenhab-addons-$OHVersion.kar"
+        $DownloadLocation = "https://www.openhab.org/download/releases/org/openhab/distro/openhab/$OHVersionName/openhab-$OHVersionName.zip"
+        $AddonsDownloadLocation = "https://www.openhab.org/download/releases/org/openhab/distro/openhab-addons/$OHVersionName/openhab-addons-$OHVersionName.kar"
     }
 
     # If we are not in SkipNew (or SkipNew and the temporary distribution file/folders have not been created yet):


### PR DESCRIPTION
Requires https://github.com/openhab/website/pull/278/files
Related to openhab/openhab-distro#1256

Signed-off-by: Kai Kreuzer <kai@openhab.org>