### PR TITLE
Prevent app.bndrun resolution issues

### DIFF
--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -91,6 +91,10 @@ feature.openhab-model-runtime-all: \
 -runblacklist: \
 	bnd.identity;id='org.apache.aries.jpa.container',\
 	bnd.identity;id='org.openhab.core.test',\
+	bnd.identity;id='osgi.annotation',\
+	bnd.identity;id='osgi.cmpn',\
+	bnd.identity;id='osgi.core',\
+	bnd.identity;id='slf4j.api',\
 	bnd.identity;id='slf4j.simple'
 
 -runvm.java9plus: \


### PR DESCRIPTION
The osgi.* bundles are compile time only and have unsatisfiable "must.not.resolve" package imports.
The slf4j.api bundle provides packages that are already provided by the pax-logging bundles.

---

This should prevent issues like in this [community topic](https://community.openhab.org/t/capabilities-satisfying-the-following-requirements-could-not-be-found/120262?u=wborn) where the wrong bundles were resolved.