### PR TITLE
Fix JAX-RS Whiteboard issues when installing add-ons creating new Applications

### DIFF
--- a/distributions/openhab/src/main/resources/bin/setenv
+++ b/distributions/openhab/src/main/resources/bin/setenv
@@ -107,6 +107,7 @@ export JAVA_OPTS="${JAVA_OPTS}
   -Djetty.host=${HTTP_ADDRESS}
   -Djetty.http.compliance=RFC2616
   -Dnashorn.args=--no-deprecation-warning
+  -Dorg.apache.cxf.osgi.http.transport.disable=true
   -Dorg.ops4j.pax.web.listening.addresses=${HTTP_ADDRESS}
   -Dorg.osgi.service.http.port=${HTTP_PORT}
   -Dorg.osgi.service.http.port.secure=${HTTPS_PORT}"

--- a/distributions/openhab/src/main/resources/bin/setenv.bat
+++ b/distributions/openhab/src/main/resources/bin/setenv.bat
@@ -124,6 +124,7 @@ set JAVA_OPTS=%JAVA_OPTS% ^
   -Djetty.host=%HTTP_ADDRESS% ^
   -Djetty.http.compliance=RFC2616 ^
   -Dnashorn.args=--no-deprecation-warning ^
+  -Dorg.apache.cxf.osgi.http.transport.disable=true ^
   -Dorg.ops4j.pax.web.listening.addresses=%HTTP_ADDRESS% ^
   -Dorg.osgi.service.http.port=%HTTP_PORT% ^
   -Dorg.osgi.service.http.port.secure=%HTTPS_PORT%

--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -82,6 +82,7 @@ feature.openhab-model-runtime-all: \
 	org.osgi.service.http.port=8080,\
 	osgi.console=,\
 	osgi.console.enable.builtin=false,\
+	org.apache.cxf.osgi.http.transport.disable=true,\
 	org.ops4j.pax.logging.DefaultServiceLog.level=WARN,\
 	openhab.servicecfg=${.}/runtime/services.cfg,\
 	openhab.conf=${.}/runtime/conf,\


### PR DESCRIPTION
This fixes the REST API breaking when installing add-ons like Hue Emulation that add a JAX-RS Whiteboard Application.
The Aries JAX-RS Whiteboard examples also use this property.

Caused by openhab/openhab-core#2316
Related to openhab/openhab-addons#10644
Fixes openhab/openhab-addons#10656