### PR TITLE
Add color to log messages in console

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/org.apache.karaf.log.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.apache.karaf.log.cfg
@@ -20,4 +20,4 @@ size = 500
 # The pattern used to format the log statement when using log:display. This pattern is according
 # to the log4j layout. You can override this parameter at runtime using log:display with -p.
 #
-pattern = %d{HH:mm:ss.SSS} [%-5.5p] [%-37.37c] - %h{%m%n}\n
+pattern = %d{HH:mm:ss.SSS} [%-5.5p] [%-37.37c] - %h{%m}%n

--- a/distributions/openhab/src/main/resources/userdata/etc/org.apache.karaf.log.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.apache.karaf.log.cfg
@@ -20,4 +20,4 @@ size = 500
 # The pattern used to format the log statement when using log:display. This pattern is according
 # to the log4j layout. You can override this parameter at runtime using log:display with -p.
 #
-pattern = %d{HH:mm:ss.SSS} [%-5.5p] [%-37.37c] - %m%n
+pattern = %d{HH:mm:ss.SSS} [%-5.5p] [%-37.37c] - %h{%m%n}\n


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-distro/issues/1293

I didn't manage to apply color to any of the parts that require a fixed width.
It thus only shows the message itself in color, not the date, level or class, but this looks quite ok.

Signed-off-by: Kai Kreuzer <kai@openhab.org>