### PR TITLE
Suppress ChannelDescriptionChangedEvent in event.log by default

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/log4j2.xml
+++ b/distributions/openhab/src/main/resources/userdata/etc/log4j2.xml
@@ -63,6 +63,7 @@
 		<Logger level="ERROR" name="openhab.event.ItemRemovedEvent"/>
 		<Logger level="ERROR" name="openhab.event.ItemChannelLinkAddedEvent"/>
 		<Logger level="ERROR" name="openhab.event.ItemChannelLinkRemovedEvent"/>
+		<Logger level="ERROR" name="openhab.event.ChannelDescriptionChangedEvent"/>
 		<Logger level="ERROR" name="openhab.event.ThingStatusInfoEvent"/>
 		<Logger level="ERROR" name="openhab.event.ThingAddedEvent"/>
 		<Logger level="ERROR" name="openhab.event.ThingUpdatedEvent"/>


### PR DESCRIPTION
- Suppress `ChannelDescriptionChangedEvent` in event.log by default

See https://community.openhab.org/t/new-zoneminder-binding-for-zoneminder-versions-1-34-0/95112/290

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>