### PR TITLE
Fix %CLASSPATH% compatibility

### DIFF
--- a/distributions/openhab/src/main/resources/bin/karaf.bat
+++ b/distributions/openhab/src/main/resources/bin/karaf.bat
@@ -391,7 +391,7 @@ if "%KARAF_PROFILER%" == "" goto :RUN
         MOVE /Y "%KARAF_HOME%\lib.next" "%KARAF_HOME%\lib"
 
         echo "Updating classpath..."
-        set CLASSPATH=%CLASSPATH_INITIAL%
+        set CLASSPATH="%CLASSPATH_INITIAL%"
         pushd "%KARAF_HOME%\lib\boot"
         for %%G in (*.jar) do call:APPEND_TO_CLASSPATH %%G
         popd


### PR DESCRIPTION
Hi,

I ran into an issue where running start.bat (Windows 10, 64 bit, JDK 11.0.11) resulted in an error like:
`"\QuickTime\QTSystem\QTJava.zip" kann syntaktisch an dieser Stelle nicht verarbeitet werden.`
(roughly translates to "cannot be processed syntactically at this point.").
It turned out the problem was my %CLASSPATH% environment variable. It has this value currently:
`.;slf4j-simple.jar;C:\Program Files (x86)\QuickTime\QTSystem\QTJava.zip`
and when executing line 394 of karaf.bat:
`set CLASSPATH=%CLASSPATH_INITIAL%`
it ran into said issue. I believe it's failing due to the space in the variable or the backslashes, though I am not sure. I have resolved it by adding quotation marks around the `%CLASSPATH_INITIAL%` variable. Don't ask me why line 106
`set CLASSPATH_INITIAL=%CLASSPATH%`
runs without issue despite using `%CLASSPATH%` without quotation marks.
This is obviously outside my area of expertise, but this one fix has made the difference between aforementioned crash and openHAB running fine on my system and I suppose space characters in the classpath could be expected on Windows.

Thank you.