### PR TITLE
gzip logs as per default log4j2 config

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -55,6 +55,9 @@ DEFAULT;$OPENHAB_USERDATA/etc/org.ops4j.pax.logging.cfg
 DEFAULT;$OPENHAB_USERDATA/etc/log4j2.xml
 DEFAULT;$OPENHAB_USERDATA/etc/org.ops4j.pax.logging.cfg
 
+[3.2.0]
+DEFAULT;$OPENHAB_USERDATA/etc/log4j2.xml
+
 [[POST]]
 [2.3.0]
 DELETE;$OPENHAB_USERDATA/etc/org.openhab.addons.cfg

--- a/distributions/openhab/src/main/resources/userdata/etc/log4j2.xml
+++ b/distributions/openhab/src/main/resources/userdata/etc/log4j2.xml
@@ -7,30 +7,33 @@
 		</Console>
 
 		<!-- Rolling file appender -->
-		<RollingFile fileName="${sys:openhab.logdir}/openhab.log" filePattern="${sys:openhab.logdir}/openhab.log.%i" name="LOGFILE">
+		<RollingFile fileName="${sys:openhab.logdir}/openhab.log" filePattern="${sys:openhab.logdir}/openhab.log.%i.gz" name="LOGFILE">
 			<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5.5p] [%-36.36c] - %m%n"/>
 			<Policies>
 				<OnStartupTriggeringPolicy/>
 				<SizeBasedTriggeringPolicy size="16 MB"/>
 			</Policies>
+			<DefaultRolloverStrategy max="7"/>
 		</RollingFile>
 
 		<!-- Event log appender -->
-		<RollingRandomAccessFile fileName="${sys:openhab.logdir}/events.log" filePattern="${sys:openhab.logdir}/events.log.%i" name="EVENT">
+		<RollingRandomAccessFile fileName="${sys:openhab.logdir}/events.log" filePattern="${sys:openhab.logdir}/events.log.%i.gz" name="EVENT">
 			<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5.5p] [%-36.36c] - %m%n"/>
 			<Policies>
 				<OnStartupTriggeringPolicy/>
 				<SizeBasedTriggeringPolicy size="16 MB"/>
 			</Policies>
+			<DefaultRolloverStrategy max="7"/>
 		</RollingRandomAccessFile>
 
 		<!-- Audit file appender -->
-		<RollingRandomAccessFile fileName="${sys:openhab.logdir}/audit.log" filePattern="${sys:openhab.logdir}/audit.log.%i" name="AUDIT">
+		<RollingRandomAccessFile fileName="${sys:openhab.logdir}/audit.log" filePattern="${sys:openhab.logdir}/audit.log.%i.gz" name="AUDIT">
 			<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5.5p] [%-36.36c] - %m%n"/>
 			<Policies>
 				<OnStartupTriggeringPolicy/>
 				<SizeBasedTriggeringPolicy size="8 MB"/>
 			</Policies>
+			<DefaultRolloverStrategy max="7"/>
 		</RollingRandomAccessFile>
 
 		<!-- OSGi appender -->

--- a/launch/app/runtime/log4j2.xml
+++ b/launch/app/runtime/log4j2.xml
@@ -6,30 +6,33 @@
 		</Console>
 
 		<!-- Rolling file appender -->
-		<RollingFile fileName="${sys:openhab.logdir}/openhab.log" filePattern="${sys:openhab.logdir}/openhab.log.%i" name="LOGFILE">
+		<RollingFile fileName="${sys:openhab.logdir}/openhab.log" filePattern="${sys:openhab.logdir}/openhab.log.%i.gz" name="LOGFILE">
 			<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5.5p] [%-36.36c] - %m%n"/>
 			<Policies>
 				<OnStartupTriggeringPolicy/>
 				<SizeBasedTriggeringPolicy size="16 MB"/>
 			</Policies>
+			<DefaultRolloverStrategy max="7"/>
 		</RollingFile>
 
 		<!-- Event log appender -->
-		<RollingRandomAccessFile fileName="${sys:openhab.logdir}/events.log" filePattern="${sys:openhab.logdir}/events.log.%i" name="EVENT">
+		<RollingRandomAccessFile fileName="${sys:openhab.logdir}/events.log" filePattern="${sys:openhab.logdir}/events.log.%i.gz" name="EVENT">
 			<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5.5p] [%-36.36c] - %m%n"/>
 			<Policies>
 				<OnStartupTriggeringPolicy/>
 				<SizeBasedTriggeringPolicy size="16 MB"/>
 			</Policies>
+			<DefaultRolloverStrategy max="7"/>
 		</RollingRandomAccessFile>
 
 		<!-- Audit file appender -->
-		<RollingRandomAccessFile fileName="${sys:openhab.logdir}/audit.log" filePattern="${sys:openhab.logdir}/audit.log.%i" name="AUDIT">
+		<RollingRandomAccessFile fileName="${sys:openhab.logdir}/audit.log" filePattern="${sys:openhab.logdir}/audit.log.%i.gz" name="AUDIT">
 			<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5.5p] [%-36.36c] - %m%n"/>
 			<Policies>
 				<OnStartupTriggeringPolicy/>
 				<SizeBasedTriggeringPolicy size="8 MB"/>
 			</Policies>
+			<DefaultRolloverStrategy max="7"/>
 		</RollingRandomAccessFile>
 
 		<!-- OSGi appender -->


### PR DESCRIPTION
Primarily to save on disk space or actually on RAM on openHABian-on-Raspi which has this in (Z)RAM 

Also explicitly defined the number of logs := 7 so people know how to change that if they want to.


Fixes: openhab/openhabian#1575

Signed-off-by: Markus Storm <markus.storm@gmx.net>