### PR TITLE
[homematic] Add alert about DOUBLE_PRESS trigger event removal

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -45,7 +45,7 @@ ALERT;Nest Binding: The binding now also supports the SDM API. To keep using the
 
 [3.2.0]
 ALERT; RFXCOM Binding: Lighting4 default command ids are deprecated and will be removed in a future version. You must specify command ids in the thing configuration for Lighting4 devices.
-
+ALERT; Homematic Binding: The DOUBLE_PRESSED trigger event was removed from the BUTTON channel. If needed, it can be replaced by a rule triggered by the SHORT_PRESSED event which employs a timer to check for double presses. 
 
 [[PRE]]
 [2.2.0]


### PR DESCRIPTION
See https://github.com/openhab/openhab-addons/pull/11186

Signed-off-by: Danny Baumann <dannybaumann@web.de>