### PR TITLE
fixes file encoding when no locale available

### DIFF
--- a/distributions/openhab/src/main/resources/bin/setenv
+++ b/distributions/openhab/src/main/resources/bin/setenv
@@ -116,7 +116,9 @@ export JAVA_OPTS="${JAVA_OPTS}
 # set JVM options
 #
 ARCH=`uname -m`
-EXTRA_JAVA_OPTS_COMMON="-Djava.awt.headless=true"
+EXTRA_JAVA_OPTS_COMMON="
+  -Djava.awt.headless=true
+  -Dfile.encoding=UTF-8"
 EXTRA_JAVA_OPTS_ARCH=""
 case "$ARCH" in
     *arm*) ;;


### PR DESCRIPTION
I experienced the issue that special characters were not correctly encoded after a restart of openHAB.  
The same issue was described within this issue:  openhab/openhab-core#291

A fix for Windows was provided within this commit:
https://github.com/openhab/openhab-distro/commit/8e94e79547e8361edb60d4d8f583156483423b0b

After digging a bit into this issue I found, that there is no locale setting on the system I'm using and it even is not installed, so I had no idea how to fix it without setting the Java Options.

If you like, I may add a check if `locale` is available and only set the `file.encoding=UTF-8` if `locale`  is not availabe like this:
```sh
if ! locale 2>/dev/null ; then 
  EXTRA_JAVA_OPTS_COMMON="${EXTRA_JAVA_OPTS_COMMON} -Dfile.encoding=UTF-8"
fi
```

The setup I use:
* RPI4 with [RasperryMatic](https://github.com/jens-maus/RaspberryMatic) installed (that's a very "lightweight, buildroot-based Linux")
* openHAB as a manual installation within the addon folder of RasperryMatic