### PR TITLE
Resolve app.bndrun for Jackson upgrade

### DIFF
--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -119,11 +119,11 @@ feature.openhab-model-runtime-all: \
 -runbundles: \
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
 	org.ops4j.pax.logging.pax-logging-log4j2;version='[2.0.10,2.0.11)',\
-	com.fasterxml.jackson.core.jackson-annotations;version='[2.12.3,2.12.4)',\
-	com.fasterxml.jackson.core.jackson-core;version='[2.12.3,2.12.4)',\
-	com.fasterxml.jackson.core.jackson-databind;version='[2.12.3,2.12.4)',\
-	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.12.3,2.12.4)',\
-	com.fasterxml.jackson.datatype.jackson-datatype-jsr310;version='[2.12.3,2.12.4)',\
+	com.fasterxml.jackson.core.jackson-annotations;version='[2.12.5,2.12.6)',\
+	com.fasterxml.jackson.core.jackson-core;version='[2.12.5,2.12.6)',\
+	com.fasterxml.jackson.core.jackson-databind;version='[2.12.5,2.12.6)',\
+	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.12.5,2.12.6)',\
+	com.fasterxml.jackson.datatype.jackson-datatype-jsr310;version='[2.12.5,2.12.6)',\
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
 	com.google.guava;version='[30.1.0,30.1.1)',\


### PR DESCRIPTION
Resolves the runbundles for the upgrade to Jackson 2.12.5.

Depends on https://github.com/openhab/openhab-core/pull/2572