### PR TITLE
This adds a new logger to our default log configuration that can be utilized by user provided scripts.

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/log4j2.xml
+++ b/distributions/openhab/src/main/resources/userdata/etc/log4j2.xml
@@ -83,6 +83,9 @@
 			<AppenderRef ref="OSGI"/>
 		</Logger>
 
+		<!-- openHAB user based script logger configuration -->
+		<Logger level="TRACE" name="org.openhab.automation.script" />
+
 		<Logger level="ERROR" name="javax.jmdns"/>
 		<Logger level="ERROR" name="org.jupnp"/>
 

--- a/launch/app/runtime/log4j2.xml
+++ b/launch/app/runtime/log4j2.xml
@@ -87,6 +87,9 @@
 			<AppenderRef ref="STDOUT"/>
 		</Logger>
 
+		<!-- openHAB user based script logger configuration -->
+		<Logger level="TRACE" name="org.openhab.automation.script" />
+		
 		<Logger level="ERROR" name="javax.jmdns"/>
 		<Logger level="ERROR" name="org.jupnp"/>
 


### PR DESCRIPTION
The JSScripting rules binding will be introducing nodejs compatible logging, so `console.log`, `console.debug`, `console.error` and so on.  This PR adds a default namespace for user script logging  which can be used by JSScripting as well as any other scripting engine.  The only messages logged using this namespace will be provided by users, which is why its severity level is set as it is. 

See https://github.com/openhab/openhab-addons/pull/11656 for the corresponding changes to the JSScripting binding.  

Signed-off-by: Dan Cunningham <dan@digitaldan.com>