### PR TITLE
Mitigate potential Remote-Code-Execution caused by CVE-2021-44228

### DIFF
--- a/distributions/openhab/src/main/resources/bin/setenv
+++ b/distributions/openhab/src/main/resources/bin/setenv
@@ -110,7 +110,8 @@ export JAVA_OPTS="${JAVA_OPTS}
   -Dorg.apache.cxf.osgi.http.transport.disable=true
   -Dorg.ops4j.pax.web.listening.addresses=${HTTP_ADDRESS}
   -Dorg.osgi.service.http.port=${HTTP_PORT}
-  -Dorg.osgi.service.http.port.secure=${HTTPS_PORT}"
+  -Dorg.osgi.service.http.port.secure=${HTTPS_PORT}
+  -Dlog4j2.formatMsgNoLookups=true"
 
 #
 # set JVM options

--- a/distributions/openhab/src/main/resources/bin/setenv.bat
+++ b/distributions/openhab/src/main/resources/bin/setenv.bat
@@ -127,7 +127,8 @@ set JAVA_OPTS=%JAVA_OPTS% ^
   -Dorg.apache.cxf.osgi.http.transport.disable=true ^
   -Dorg.ops4j.pax.web.listening.addresses=%HTTP_ADDRESS% ^
   -Dorg.osgi.service.http.port=%HTTP_PORT% ^
-  -Dorg.osgi.service.http.port.secure=%HTTPS_PORT%
+  -Dorg.osgi.service.http.port.secure=%HTTPS_PORT% ^
+  -Dlog4j2.formatMsgNoLookups=true
 
 :: set jvm options
 set EXTRA_JAVA_OPTS=-XX:+UseG1GC ^


### PR DESCRIPTION
This is a mitigation for the issue mentioned in https://community.openhab.org/t/log4j-vulnerability/129863 until Karaf has been updated. However, we could leave this in "forever" since I don't see any reason why openHAB should ever use JNDI in logging-messages, so this adds an additional protection in case there are more shady things going on in the jndi code in log4j.