### PR TITLE
Upgrade to Karaf 4.3.4

### DIFF
--- a/distributions/openhab/src/main/filtered-resources/userdata/etc/org.apache.karaf.features.cfg
+++ b/distributions/openhab/src/main/filtered-resources/userdata/etc/org.apache.karaf.features.cfg
@@ -88,7 +88,7 @@ configCfgStore=false
 #
 # Define if the feature service automatically refresh bundles
 #
-#autoRefresh=true
+autoRefresh=true
 
 #
 # Configuration of features processing mechanism (overrides, blacklisting, modification of features)

--- a/distributions/openhab/src/main/resources/bin/karaf
+++ b/distributions/openhab/src/main/resources/bin/karaf
@@ -301,8 +301,8 @@ run() {
                 ${KARAF_EXEC} "${JAVA}" ${JAVA_OPTS} \
                     --add-reads=java.xml=java.logging \
                     --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED \
-                    --patch-module "java.base=${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.locator-4.3.3.jar" \
-                    --patch-module "java.xml=${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.java.xml-4.3.3.jar" \
+                    --patch-module "java.base=${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.locator-4.3.4.jar" \
+                    --patch-module "java.xml=${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.java.xml-4.3.4.jar" \
                     --add-opens java.base/java.security=ALL-UNNAMED \
                     --add-opens java.base/java.net=ALL-UNNAMED \
                     --add-opens java.base/java.lang=ALL-UNNAMED \

--- a/distributions/openhab/src/main/resources/bin/karaf.bat
+++ b/distributions/openhab/src/main/resources/bin/karaf.bat
@@ -407,8 +407,8 @@ if "%KARAF_PROFILER%" == "" goto :RUN
             "%JAVA%" %JAVA_OPTS% %OPTS% ^
                 --add-reads=java.xml=java.logging ^
                 --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED ^
-                --patch-module "java.base=%KARAF_HOME%/lib/endorsed/org.apache.karaf.specs.locator-4.3.3.jar" ^
-                --patch-module "java.xml=%KARAF_HOME%/lib/endorsed/org.apache.karaf.specs.java.xml-4.3.3.jar" ^
+                --patch-module "java.base=%KARAF_HOME%/lib/endorsed/org.apache.karaf.specs.locator-4.3.4.jar" ^
+                --patch-module "java.xml=%KARAF_HOME%/lib/endorsed/org.apache.karaf.specs.java.xml-4.3.4.jar" ^
                 --add-opens java.base/java.security=ALL-UNNAMED ^
                 --add-opens java.base/java.net=ALL-UNNAMED ^
                 --add-opens java.base/java.lang=ALL-UNNAMED ^

--- a/distributions/openhab/src/main/resources/bin/setenv
+++ b/distributions/openhab/src/main/resources/bin/setenv
@@ -110,8 +110,7 @@ export JAVA_OPTS="${JAVA_OPTS}
   -Dorg.apache.cxf.osgi.http.transport.disable=true
   -Dorg.ops4j.pax.web.listening.addresses=${HTTP_ADDRESS}
   -Dorg.osgi.service.http.port=${HTTP_PORT}
-  -Dorg.osgi.service.http.port.secure=${HTTPS_PORT}
-  -Dlog4j2.formatMsgNoLookups=true"
+  -Dorg.osgi.service.http.port.secure=${HTTPS_PORT}"
 
 #
 # set JVM options

--- a/distributions/openhab/src/main/resources/bin/setenv.bat
+++ b/distributions/openhab/src/main/resources/bin/setenv.bat
@@ -127,8 +127,7 @@ set JAVA_OPTS=%JAVA_OPTS% ^
   -Dorg.apache.cxf.osgi.http.transport.disable=true ^
   -Dorg.ops4j.pax.web.listening.addresses=%HTTP_ADDRESS% ^
   -Dorg.osgi.service.http.port=%HTTP_PORT% ^
-  -Dorg.osgi.service.http.port.secure=%HTTPS_PORT% ^
-  -Dlog4j2.formatMsgNoLookups=true
+  -Dorg.osgi.service.http.port.secure=%HTTPS_PORT%
 
 :: set jvm options
 set EXTRA_JAVA_OPTS=-XX:+UseG1GC ^

--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -116,8 +116,8 @@ feature.openhab-model-runtime-all: \
 # done
 #
 -runbundles: \
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.10,2.0.11)',\
-	org.ops4j.pax.logging.pax-logging-log4j2;version='[2.0.10,2.0.11)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.12,2.0.13)',\
+	org.ops4j.pax.logging.pax-logging-log4j2;version='[2.0.12,2.0.13)',\
 	com.fasterxml.jackson.core.jackson-annotations;version='[2.12.5,2.12.6)',\
 	com.fasterxml.jackson.core.jackson-core;version='[2.12.5,2.12.6)',\
 	com.fasterxml.jackson.core.jackson-databind;version='[2.12.5,2.12.6)',\
@@ -162,7 +162,7 @@ feature.openhab-model-runtime-all: \
 	org.apache.felix.gogo.shell;version='[1.1.4,1.1.5)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.inventory;version='[1.1.0,1.1.1)',\
-	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
+	org.apache.felix.scr;version='[2.1.30,2.1.31)',\
 	org.apache.felix.webconsole;version='[4.7.0,4.7.1)',\
 	org.apache.felix.webconsole.plugins.ds;version='[2.1.0,2.1.1)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
@@ -207,17 +207,17 @@ feature.openhab-model-runtime-all: \
 	org.objectweb.asm.tree;version='[9.0.0,9.0.1)',\
 	org.objectweb.asm.tree.analysis;version='[9.0.0,9.0.1)',\
 	org.objectweb.asm.util;version='[9.0.0,9.0.1)',\
-	org.ops4j.pax.web.pax-web-api;version='[7.3.19,7.3.20)',\
-	org.ops4j.pax.web.pax-web-extender-whiteboard;version='[7.3.19,7.3.20)',\
-	org.ops4j.pax.web.pax-web-jetty;version='[7.3.19,7.3.20)',\
-	org.ops4j.pax.web.pax-web-runtime;version='[7.3.19,7.3.20)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.3.19,7.3.20)',\
+	org.ops4j.pax.web.pax-web-api;version='[7.3.23,7.3.24)',\
+	org.ops4j.pax.web.pax-web-extender-whiteboard;version='[7.3.23,7.3.24)',\
+	org.ops4j.pax.web.pax-web-jetty;version='[7.3.23,7.3.24)',\
+	org.ops4j.pax.web.pax-web-runtime;version='[7.3.23,7.3.24)',\
+	org.ops4j.pax.web.pax-web-spi;version='[7.3.23,7.3.24)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.osgi.service.jaxrs;version='[1.0.0,1.0.1)',\
 	org.osgi.service.metatype;version='[1.4.0,1.4.1)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
 	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	org.yaml.snakeyaml;version='[1.27.0,1.27.1)',\
 	si-units;version='[2.1.0,2.1.1)',\

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <ohc.version>3.2.0-SNAPSHOT</ohc.version>
         <oha.version>3.2.0-SNAPSHOT</oha.version>
 
-        <karaf.version>4.3.3</karaf.version>
+        <karaf.version>4.3.4</karaf.version>
 
         <oh.java.version>11</oh.java.version>
         <maven.compiler.source>${oh.java.version}</maven.compiler.source>


### PR DESCRIPTION
* Syncs distro customizations with Karaf 4.3.4
* Resolves app runbundles for the new dependencies

For release notes, see:

https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12350547

Karaf 4.3.4 uses Pax Logging 2.0.12 which fixes CVE-2021-44228 and CVE-2021-45046.

See also these advisories:

* Log4j: [GHSA-jfh8-c2jp-5v3q](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q), [GHSA-7rjr-3q55-vv33](https://github.com/advisories/GHSA-7rjr-3q55-vv33)
* Pax Logging: [GHSA-xxfh-x98p-j8fr](https://github.com/advisories/GHSA-xxfh-x98p-j8fr)

Fixes #1334

---

Depends on:

* https://github.com/openhab/openhab-core/pull/2603
* https://github.com/openhab/openhab-addons/pull/11750
* https://github.com/openhab/openhab-webui/pull/1228