### PR TITLE
Use Pax Logging 2.0.13

### DIFF
--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -116,6 +116,7 @@
                     <startupFeatures>
                         <feature>eventadmin</feature>
                     </startupFeatures>
+                    <featuresProcessing>${basedir}/processing.xml</featuresProcessing>
                     <bootFeatures>
                         <feature>jaas</feature>
                         <feature>shell</feature>

--- a/distributions/openhab/processing.xml
+++ b/distributions/openhab/processing.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<featuresProcessing xmlns="http://karaf.apache.org/xmlns/features-processing/v1.0.0">
+
+    <bundleReplacements>
+        <bundle originalUri="mvn:org.ops4j.pax.logging/pax-logging-api/[0,2.0.13)" replacement="mvn:org.ops4j.pax.logging/pax-logging-api/2.0.13" mode="maven" />
+        <bundle originalUri="mvn:org.ops4j.pax.logging/pax-logging-log4j2/[0,2.0.13)" replacement="mvn:org.ops4j.pax.logging/pax-logging-log4j2/2.0.13" mode="maven" />
+        <bundle originalUri="mvn:org.ops4j.pax.logging/pax-logging-logback/[0,2.0.13)" replacement="mvn:org.ops4j.pax.logging/pax-logging-logback/2.0.13" mode="maven" />
+    </bundleReplacements>
+
+</featuresProcessing>

--- a/distributions/openhab/src/main/descriptors/archive.xml
+++ b/distributions/openhab/src/main/descriptors/archive.xml
@@ -51,6 +51,9 @@
                 <include>system/**</include>
                 <include>bin/*.lst</include>
             </includes>
+            <excludes>
+                <exclude>system/org/ops4j/pax/logging/*/2.0.12/**</exclude>
+            </excludes>
             <!-- specifically fixes https://github.com/openhab/openhab-distro/issues/503 -->
             <fileMode>0644</fileMode>
         </fileSet>


### PR DESCRIPTION
Pax Logging 2.0.13 uses log4j2 2.17 which fixes CVE-2021-45105.

Also-by: Łukasz Dywicki <luke@code-house.org>
Signed-off-by: Wouter Born <github@maindrain.net>