### PR TITLE
Added feature openhab-iconset-classic to ui runtime

### DIFF
--- a/features/distro/src/main/feature/feature.xml
+++ b/features/distro/src/main/feature/feature.xml
@@ -3,9 +3,10 @@
 
     <feature name="openhab-runtime-ui" description="openHAB UI" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <feature>openhab-iconset-classic</feature>
         <feature>openhab-core-ui</feature>
+        <feature>openhab-core-ui-icon</feature>
         <bundle>mvn:org.openhab.ui.bundles/org.openhab.ui/${project.version}</bundle>
+        <bundle>mvn:org.openhab.ui.bundles/org.openhab.ui.iconset.classic/${project.version}</bundle>
     </feature>
 
     <feature name="openhab-package-standard" description="openHAB Standard Package" version="${project.version}">

--- a/features/distro/src/main/feature/feature.xml
+++ b/features/distro/src/main/feature/feature.xml
@@ -3,6 +3,7 @@
 
     <feature name="openhab-runtime-ui" description="openHAB UI" version="${project.version}">
         <feature>openhab-runtime-base</feature>
+        <feature>openhab-iconset-classic</feature>
         <feature>openhab-core-ui</feature>
         <bundle>mvn:org.openhab.ui.bundles/org.openhab.ui/${project.version}</bundle>
     </feature>


### PR DESCRIPTION
- Added feature openhab-iconset-classic to ui runtime

When beside Main UI no other UI bundle is installed the icons are not displayed.

Closes https://github.com/openhab/openhab-core/issues/2730

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>