### PR TITLE
Allow runtime changes to Jetty keystore

### DIFF
--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -154,4 +154,16 @@
                 <Arg>org.eclipse.jetty.server.Request.maxFormContentSize</Arg>
                 <Arg>300000</Arg>
 	</Call>
+	<Call name="addBean">
+		<Arg>
+			<New id="keyStoreScanner" class="org.eclipse.jetty.util.ssl.KeyStoreScanner">
+				<Arg>
+					<Ref refid="sslContextFactory"/>
+				</Arg>
+				<Set name="scanInterval">
+					<Property name="jetty.sslContext.reload.scanInterval" default="15"/>
+				</Set>
+			</New>
+		</Arg>
+	</Call>
 </Configure>


### PR DESCRIPTION
This enables the Jetty `KeyStoreScanner` to allow changing the server certificate at runtime. Changes may take up to 15s to be effective.

Signed-off-by: Jan N. Klug <github@klug.nrw>