### PR TITLE
Remove Ephemeris default configuration

### DIFF
--- a/distributions/openhab/src/main/resources/conf/services/runtime.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/runtime.cfg
@@ -46,19 +46,6 @@
 #
 #org.openhab.voice:defaultHLI=
 
-################### EPHEMERIS ###################
-
-# This parameter defines the default list of usual non workable days for the Ephemeris service.
-# The value has to be surrounded by square brackets ('[' and ']') and optionally contain value delimiters - a comma ',' to be interpreted as a list of values.
-# Example: [SATURDAY,SUNDAY]
-#
-org.openhab.ephemeris:dayset-weekend=[SATURDAY,SUNDAY]
-
-# This parameter defines the default list of usual workable days for the Ephemeris service.
-# The value has to be surrounded by square brackets ('[' and ']') and optionally contain value delimiters - a comma ',' to be interpreted as a list of values.
-#
-org.openhab.ephemeris:dayset-school=[MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY]
-
 ################ MISCELLANOUS ###################
 
 # The karaf sshHost parameter configures the bind address for the ssh login to karaf.


### PR DESCRIPTION
Related to https://github.com/openhab/openhab-core/issues/1281

The system starts fine without it. This also enables configuring via UI, because the default configuration always overwrites any changes.

Signed-off-by: Jan N. Klug <github@klug.nrw>