### PR TITLE
Add .gradle to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode
 .DS_Store
 *.iml
+.gradle
 maven-metadata-local.xml
 Californium.properties
 


### PR DESCRIPTION
While openHAB uses Maven, under some circumstances IntelliJ creates files in the .gradle/ directory.

Signed-off-by: Jan N. Klug <github@klug.nrw>