### PR TITLE
Add JS Scripting Automation warning for breaking changes

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -64,14 +64,14 @@ ALERT;Sony Projector Binding: The type of the channel 'power' was updated. You m
 ALERT;BMW ConnectedDrive Binding: BMW replaced ConnectedDrive Smartphone App with MyBMW Application. Underlying API is now disabled and the Binding isn't working anymore. Switch to new introduced MyBMW Binding recommended.
 ALERT;Daikin Binding: The channel 'specialmode-powerful' has been removed, and a r/w channel 'streamer' added. The channel 'specialmode' changed to read/write to control eco/powerful mode.
 ALERT;DanfossAirUnit Binding: The type of the channel 'humidity' was updated. You may need to remove and create your things again in case your things were previously created using UI and you want to use this channel.
+ALERT;JS Scripting Automation: 'item.history.lastUpdate()' returns 'time.ZonedDateTime' instead of 'Date'
+ALERT;JS Scripting Automation: 'addItem(...)' and 'updateItem(...)' use new itemConfig as parameter and 'createItem(...)' was removed
 ALERT;MQTT Binding: Support for the MQTT System Broker has been removed. Replace 'mqtt:systemBroker' things with 'mqtt:broker' things.
+ALERT;Netatmo Binding: Things hierarchy and organization has changed as well as channel namings. You will need to remove and create again these things.
 ALERT;OmniLink Binding: The channel 'sysdate' has been renamed to 'system_date', and is now read only, to make these changes visible you may need to remove and recreate the `controller` thing. To synchronize the controller time there is now a new action synchronizeControllerTime that can be used with a time zone input (e.g. 'America/Denver').
 ALERT;Opentherm Gateway Binding: The 'otgw' Thing has been removed and split into a new 'openthermgateway' Bridge, and a new 'boiler' Thing. You will need to change your Thing and respective Item definitions.
 ALERT;RFXCOM Binding: The channel 'fanSpeed' of 'fan_lucci_dc' and 'fan_novy' has been renamed to 'fanSpeedControl', and 'fan_lucci_dc' has a new numeric channel 'fanSpeed'. You may need to remove and create your things again.
 ALERT;TapoControl Binding: L510_Series and L530_Series Things were renamed to L510 and L530 because of manufacturer changed naming with new HW-rev. You may need to remove and create again these things.
-ALERT;Netatmo Binding: Things hierarchy and organization has changed as well as channel namings. You will need to remove and create again these things.
-ALERT;JS Scripting Automation: 'item.history.lastUpdate()' returns 'time.ZonedDateTime' instead of 'Date'
-ALERT;JS Scripting Automation: 'addItem(...)' and 'updateItem(...)' use new itemConfig as parameter and 'createItem(...)' was removed
 
 [[PRE]]
 [2.2.0]

--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -70,6 +70,8 @@ ALERT;Opentherm Gateway Binding: The 'otgw' Thing has been removed and split int
 ALERT;RFXCOM Binding: The channel 'fanSpeed' of 'fan_lucci_dc' and 'fan_novy' has been renamed to 'fanSpeedControl', and 'fan_lucci_dc' has a new numeric channel 'fanSpeed'. You may need to remove and create your things again.
 ALERT;TapoControl Binding: L510_Series and L530_Series Things were renamed to L510 and L530 because of manufacturer changed naming with new HW-rev. You may need to remove and create again these things.
 ALERT;Netatmo Binding: Things hierarchy and organization has changed as well as channel namings. You will need to remove and create again these things.
+ALERT;JS Scripting Automation: 'item.history.lastUpdate()' returns 'time.ZonedDateTime' instead of 'Date'
+ALERT;JS Scripting Automation: 'addItem(...)' and 'updateItem(...)' use new itemConfig as parameter and 'createItem(...)' was removed
 
 [[PRE]]
 [2.2.0]


### PR DESCRIPTION
This adds two warnings for two breaking changes from the openhab-js library included in the JS Scripting Automation Add-On:
* https://github.com/openhab/openhab-js/pull/67
* https://github.com/openhab/openhab-js/pull/109

@digitaldan 
I have added warnings for two latest breaking changes that will affect the upcoming openHAB 3.3.0 Stable release.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>