### PR TITLE
Adding alert for WLED binding breaking change

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -72,6 +72,7 @@ ALERT;OmniLink Binding: The channel 'sysdate' has been renamed to 'system_date',
 ALERT;Opentherm Gateway Binding: The 'otgw' Thing has been removed and split into a new 'openthermgateway' Bridge, and a new 'boiler' Thing. You will need to change your Thing and respective Item definitions.
 ALERT;RFXCOM Binding: The channel 'fanSpeed' of 'fan_lucci_dc' and 'fan_novy' has been renamed to 'fanSpeedControl', and 'fan_lucci_dc' has a new numeric channel 'fanSpeed'. You may need to remove and create your things again.
 ALERT;TapoControl Binding: L510_Series and L530_Series Things were renamed to L510 and L530 because of manufacturer changed naming with new HW-rev. You may need to remove and create again these things.
+ALERT;WLED Binding: Binding now uses Bridge and Thing structure. Delete and add a new bridge, and at least 1 thing for each segment you require.
 
 [[PRE]]
 [2.2.0]


### PR DESCRIPTION
@lolodomo requested I create this alert due to new changes in a PR here:

https://github.com/openhab/openhab-addons/pull/12199

Signed-off-by: Matthew Skinner <matt@pcmus.com>