### PR TITLE
Add move instruction for transformation database

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -170,3 +170,6 @@ DELETEDIR;$OPENHAB_USERDATA/config/org/openhab/io/metrics
 
 [3.3.0]
 DELETE;$OPENHAB_USERDATA/config/org/openhab/mqttbroker.config
+
+[3.4.0]
+MOVE;$OPENHAB_USERDATA/jsondb/org.openhab.core.transform.TransformationConfiguration.json;$OPENHAB_USERDATA/jsondb/org.openhab.core.transform.Transformation.json


### PR DESCRIPTION
Related to https://github.com/openhab/openhab-core/pull/3036

Although it is not very likely that someone already used it prior to the refactoring this will not hurt and save some trouble if someone did.

Signed-off-by: Jan N. Klug <github@klug.nrw>