### PR TITLE
[velux] Alert about category correction of window channels

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -78,7 +78,7 @@ ALERT;WLED Binding: Binding now uses Bridge and Thing structure. Delete and add 
 [3.4.0]
 ALERT;Automower Binding: Due to Husqvarna Authentication API change, bridge now requires application secret instead of username and password. Delete any existing bridge and re-add it, please make sure to update all automower things to use the newly added bridge.
 ALERT;Konnected Binding: Things needs to be recreated because of added Konnected Pro panel support and manual configuration of things.
-ALERT;Velux Binding: The semantic category of window position channels has been corrected from 'blinds' to 'window'. Things with such channels that had been created via the UI will need to be deleted and re-created.
+ALERT;Velux Binding: On window things the semantic category of the position channel has been corrected from 'blinds' to 'window'. Window things with such channels that had been created via the UI will need to be deleted and re-created.
 
 [[PRE]]
 [2.2.0]

--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -78,6 +78,7 @@ ALERT;WLED Binding: Binding now uses Bridge and Thing structure. Delete and add 
 [3.4.0]
 ALERT;Automower Binding: Due to Husqvarna Authentication API change, bridge now requires application secret instead of username and password. Delete any existing bridge and re-add it, please make sure to update all automower things to use the newly added bridge.
 ALERT;Konnected Binding: Things needs to be recreated because of added Konnected Pro panel support and manual configuration of things.
+ALERT;Velux Binding: The semantic category of window position channels has been corrected from 'blinds' to 'window'. Things with such channels that had been created via the UI will need to be deleted and re-created.
 
 [[PRE]]
 [2.2.0]


### PR DESCRIPTION
In PR #13271 we corrected the 'category' of window position channels from 'blinds' to 'window'. This PR adds an alert to the release notes to explain this correction.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>