### PR TITLE
Add breaking change warning for JS Scripting

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -78,7 +78,8 @@ ALERT;WLED Binding: Binding now uses Bridge and Thing structure. Delete and add 
 [3.4.0]
 ALERT;CORE: Default units have been added for all dimensions. A state description defining the unit should be added to each item that uses a different unit.
 ALERT;Automower Binding: Due to Husqvarna Authentication API change, bridge now requires application secret instead of username and password. Delete any existing bridge and re-add it, please make sure to update all automower things to use the newly added bridge.
-ALERT;JS Scripting Automation: 'setTimeout' and 'setInterval' return a timerId (a positive integer value) as in standard JS instead of an openHAB Timer.
+ALERT;JavaScript Scripting Automation: 'setTimeout' and 'setInterval' return a timerId (a positive integer value) as in standard JS instead of an openHAB Timer.
+ALERT;JavaScript Scripting Automation: ItemHistory min/max between/since returns now a number instead of a string.
 ALERT;Konnected Binding: Things needs to be recreated because of added Konnected Pro panel support and manual configuration of things.
 ALERT;LG webOS Binding: The undocumented action "sendRCButton" was removed while it is possible to achieve the same action with "sendButton"; in case you were using "sendButton" with ENTER or DELETE as parameter, you should now use the new action "sendKeyboard".
 ALERT;Miele@home Binding: The channel 'start' now contains date and time for start of scheduled program. Previously it was counting down duration until the program would start.


### PR DESCRIPTION
Reference https://github.com/openhab/openhab-js/pull/175.

Although I can not imagine that this change breaks a user script, as most users would have parsed the string to a number, we should add a warning. I also changed the name from JS Scripting Automation to JavaScript Automation since we renamed the addon.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>