### PR TITLE
Ephemeris configuration

### DIFF
--- a/distributions/openhab/src/main/resources/conf/services/runtime.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/runtime.cfg
@@ -127,18 +127,29 @@
 #
 #org.openhab.network:useIPv6=true
 
-################### EPHEMERIS ###################
+################################## EPHEMERIS ###################################
 
 # This parameter defines the default list of usual non workable days for the Ephemeris service.
 # The value has to be surrounded by square brackets ('[' and ']') and optionally contain value delimiters - a comma ',' to be interpreted as a list of values.
 # Example: [SATURDAY,SUNDAY]
 #
-org.openhab.ephemeris:dayset-weekend=[SATURDAY,SUNDAY]
+#org.openhab.ephemeris:dayset-weekend=[SATURDAY,SUNDAY]
 
-# This parameter defines the default list of usual workable days for the Ephemeris service.
-# The value has to be surrounded by square brackets ('[' and ']') and optionally contain value delimiters - a comma ',' to be interpreted as a list of values.
+# See https://jollyday.sourceforge.net/data.html for help with the following parameters.
+# This parameter defines the specific country to get the holidays for.
+# Examples: Germany = "de", United States of America = "us"
 #
-org.openhab.ephemeris:dayset-school=[MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY]
+#org.openhab.ephemeris:country=de
+
+# This parameter defines the specific region/state to get the holidays for.
+# Examples: New York = "ny", Baden-Wuerttemberg = "bw"
+#
+#org.openhab.ephemeris:region=
+
+# This parameter defines the specific city to get the holidays for.
+# Examples: München = "mu"
+#
+#org.openhab.ephemeris:city=
 
 ################################# MISCELLANOUS #################################
 

--- a/distributions/openhab/src/main/resources/conf/services/runtime.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/runtime.cfg
@@ -127,6 +127,18 @@
 #
 #org.openhab.network:useIPv6=true
 
+################### EPHEMERIS ###################
+
+# This parameter defines the default list of usual non workable days for the Ephemeris service.
+# The value has to be surrounded by square brackets ('[' and ']') and optionally contain value delimiters - a comma ',' to be interpreted as a list of values.
+# Example: [SATURDAY,SUNDAY]
+#
+org.openhab.ephemeris:dayset-weekend=[SATURDAY,SUNDAY]
+
+# This parameter defines the default list of usual workable days for the Ephemeris service.
+# The value has to be surrounded by square brackets ('[' and ']') and optionally contain value delimiters - a comma ',' to be interpreted as a list of values.
+#
+org.openhab.ephemeris:dayset-school=[MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY]
 
 ################################# MISCELLANOUS #################################
 

--- a/distributions/openhab/src/main/resources/conf/services/runtime.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/runtime.cfg
@@ -139,7 +139,7 @@
 # This parameter defines the specific country to get the holidays for.
 # Examples: Germany = "de", United States of America = "us"
 #
-#org.openhab.ephemeris:country=de
+#org.openhab.ephemeris:country=
 
 # This parameter defines the specific region/state to get the holidays for.
 # Examples: New York = "ny", Baden-Wuerttemberg = "bw"


### PR DESCRIPTION
This reverts the removal of the Ephemeris configuration in #1387.
The configuration was removed back then, because the default values blocked editing Ephemeris from the UI.

This adds Ephemeris configuration **commented out** back and updates for the current configuration.

For configuration, see https://github.com/openhab/openhab-core/blob/main/bundles/org.openhab.core.ephemeris/src/main/resources/OH-INF/config/ephemeris.xml.
For examples, see https://jollyday.sourceforge.net/data/de.html.