### PR TITLE
Ensure metadata is loaded at startlevel 20

### DIFF
--- a/distributions/openhab/src/main/resources/runtime/services.cfg
+++ b/distributions/openhab/src/main/resources/runtime/services.cfg
@@ -14,7 +14,7 @@ threadpool:safeCall=10
 threadpool:thingHandler=5
 
 # Start level definitions
-startlevel:20=dsl:items,managed:item,dsl:things,managed:thing,managed:itemchannellink,dsl:persist
+startlevel:20=dsl:items,managed:item,dsl:things,managed:thing,managed:itemchannellink,dsl:persist,managed:metadata
 startlevel:30=persistence:restore
 startlevel:40=dsl:rules,managed:rule,rules:refresh,rules:dslprovider
 startlevel:50=ruleengine:start


### PR DESCRIPTION
This completes https://github.com/openhab/openhab-core/pull/3273 and MUST NOT be merged before, otherwise the system hangs at startlevel 10.

Signed-off-by: Jan N. Klug <github@klug.nrw>