### PR TITLE
Ensure script engine factories are loaded before rule engine starts

### DIFF
--- a/distributions/openhab/src/main/resources/runtime/services.cfg
+++ b/distributions/openhab/src/main/resources/runtime/services.cfg
@@ -14,9 +14,8 @@ threadpool:safeCall=10
 threadpool:thingHandler=5
 
 # Start level definitions
- startlevel:20=dsl:items,managed:item,dsl:things,managed:thing,managed:itemchannellink,dsl:persist,managed:metadata
+startlevel:20=dsl:items,managed:item,dsl:things,managed:thing,managed:itemchannellink,dsl:persist,managed:metadata
 startlevel:30=persistence:restore,automation:scriptEngineFactories
-startlevel:40=dsl:rules,managed:rule,rules:refresh,rules:dslprovider,automation:scriptEngineFactories
 startlevel:40=dsl:rules,managed:rule,rules:refresh,rules:dslprovider
 startlevel:50=ruleengine:start
 startlevel:70=dsl:sitemap

--- a/distributions/openhab/src/main/resources/runtime/services.cfg
+++ b/distributions/openhab/src/main/resources/runtime/services.cfg
@@ -16,7 +16,7 @@ threadpool:thingHandler=5
 # Start level definitions
 startlevel:20=dsl:items,managed:item,dsl:things,managed:thing,managed:itemchannellink,dsl:persist,managed:metadata
 startlevel:30=persistence:restore
-startlevel:40=dsl:rules,managed:rule,rules:refresh,rules:dslprovider
+startlevel:40=dsl:rules,managed:rule,rules:refresh,rules:dslprovider,automation:scriptEngineFactories
 startlevel:50=ruleengine:start
 startlevel:70=dsl:sitemap
 startlevel:80=things:handler

--- a/distributions/openhab/src/main/resources/runtime/services.cfg
+++ b/distributions/openhab/src/main/resources/runtime/services.cfg
@@ -14,9 +14,10 @@ threadpool:safeCall=10
 threadpool:thingHandler=5
 
 # Start level definitions
-startlevel:20=dsl:items,managed:item,dsl:things,managed:thing,managed:itemchannellink,dsl:persist,managed:metadata
-startlevel:30=persistence:restore
+ startlevel:20=dsl:items,managed:item,dsl:things,managed:thing,managed:itemchannellink,dsl:persist,managed:metadata
+startlevel:30=persistence:restore,automation:scriptEngineFactories
 startlevel:40=dsl:rules,managed:rule,rules:refresh,rules:dslprovider,automation:scriptEngineFactories
+startlevel:40=dsl:rules,managed:rule,rules:refresh,rules:dslprovider
 startlevel:50=ruleengine:start
 startlevel:70=dsl:sitemap
 startlevel:80=things:handler


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-core/pull/3275

This MUST NOT be merged before, otherwise the system hangs at startlevel 20.

Signed-off-by: Jan N. Klug <github@klug.nrw>