### PR TITLE
Install JS Scripting (GraalJS) by default

### DIFF
--- a/distributions/openhab-demo/src/main/resources/conf/services/addons.cfg
+++ b/distributions/openhab-demo/src/main/resources/conf/services/addons.cfg
@@ -15,7 +15,7 @@ package = standard
 #remote = true
 
 # A comma-separated list of automation services to install (e.g. "automation = groovyscripting")
-#automation = 
+automation = jsscripting
 
 # A comma-separated list of bindings to install (e.g. "binding = knx,sonos,zwave")
 binding = astro,avmfritz,hue,ntp,sonos,wemo

--- a/features/distro/src/main/feature/feature.xml
+++ b/features/distro/src/main/feature/feature.xml
@@ -13,6 +13,7 @@
         <feature>openhab-runtime-base</feature>
         <config name="org.openhab.addons" append="true">
 			package = standard
+			automation = jsscripting
 			ui = basic,habpanel
 			persistence = rrd4j
         </config>


### PR DESCRIPTION
With https://github.com/openhab/openhab-webui/issues/1597 getting resolved soon, Blockly will depend on JS Scripting (GraalJS). Therefore it needs to be installed by default.

@wborn Ping.