### PR TITLE
Enable GZIP compression for Jetty webserver

### DIFF
--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -57,7 +57,13 @@
 			</Arg>
 		</Call>
 	</Get>
-
+	<Call name="insertHandler">
+		<Arg>
+			<New id="GzipHandler" class="org.eclipse.jetty.server.handler.gzip.GzipHandler">
+				<Set name="minGzipSize">1024</Set>
+			</New>
+		</Arg>
+	</Call>
 
 	<New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
 		<Set name="secureScheme">https</Set>

--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -61,6 +61,11 @@
 		<Arg>
 			<New id="GzipHandler" class="org.eclipse.jetty.server.handler.gzip.GzipHandler">
 				<Set name="minGzipSize">1024</Set>
+				<Set name="includedPaths">
+					<Array type="java.lang.String">
+						<Item>/rest/*</Item>
+					</Array>
+				</Set>
 			</New>
 		</Arg>
 	</Call>


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-core/issues/3313