### PR TITLE
Install JS Scripting on openhab-demo server

### DIFF
--- a/distributions/openhab-demo/src/main/resources/conf/services/addons.cfg
+++ b/distributions/openhab-demo/src/main/resources/conf/services/addons.cfg
@@ -15,7 +15,7 @@ package = standard
 #remote = true
 
 # A comma-separated list of automation services to install (e.g. "automation = groovyscripting")
-#automation = 
+automation = groovyscripting,jsscripting,jythonscripting
 
 # A comma-separated list of bindings to install (e.g. "binding = knx,sonos,zwave")
 binding = astro,avmfritz,hue,ntp,sonos,wemo


### PR DESCRIPTION
With the Blockly port to JS Scripting and the removal of NashornJS from core, we need a JS ScriptEngine in openHAB 4.0 to make Blockly work.

This installs JS Scripting on the openHAB demo server and adds the already installed addons to the config file.

See https://github.com/openhab/openhab-distro/pull/1455#issuecomment-1368064700 for previous discussion.

/cc @kaikreuzer 