### PR TITLE
Fix SSE streams when using GZIP

### DIFF
--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -66,6 +66,12 @@
 						<Item>/rest/*</Item>
 					</Array>
 				</Set>
+				<Set name="excludedPaths">
+					<Array type="java.lang.String">
+						<Item>/rest/events/*</Item>
+						<Item>/rest/sitemaps/events/*</Item>
+					</Array>
+				</Set>
 			</New>
 		</Arg>
 	</Call>

--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -66,10 +66,11 @@
 						<Item>/rest/*</Item>
 					</Array>
 				</Set>
-				<Set name="excludedPaths">
+				<Set name="includedMimeTypes">
 					<Array type="java.lang.String">
-						<Item>/rest/events/*</Item>
-						<Item>/rest/sitemaps/events/*</Item>
+						<Item>application/json</Item>
+						<Item>text/html</Item>
+						<Item>text/plain</Item>
 					</Array>
 				</Set>
 			</New>


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-webui/issues/1757

It seems that enabling GZIP for the SSE endpoints breaks the ecent stream.