### PR TITLE
Resolve app.bndrun runbundles for HTTP/2 support and XStream upgrade

### DIFF
--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -178,8 +178,12 @@ feature.openhab-model-runtime-all: \
 	org.eclipse.equinox.common;version='[3.16.200,3.16.201)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.eclipse.equinox.metatype;version='[1.4.500,1.4.501)',\
+	org.eclipse.jetty.alpn.client;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.client;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.http;version='[9.4.50,9.4.51)',\
+	org.eclipse.jetty.http2.client;version='[9.4.50,9.4.51)',\
+	org.eclipse.jetty.http2.common;version='[9.4.50,9.4.51)',\
+	org.eclipse.jetty.http2.hpack;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.io;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.jaas;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.proxy;version='[9.4.50,9.4.51)',\
@@ -225,7 +229,7 @@ feature.openhab-model-runtime-all: \
 	stax2-api;version='[4.2.1,4.2.2)',\
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
-	xstream;version='[1.4.19,1.4.20)',\
+	xstream;version='[1.4.20,1.4.21)',\
 	org.openhab.core;version='[4.0.0,4.0.1)',\
 	org.openhab.core.addon;version='[4.0.0,4.0.1)',\
 	org.openhab.core.addon.eclipse;version='[4.0.0,4.0.1)',\


### PR DESCRIPTION
Related to:

* openhab/openhab-core#3433
* openhab/openhab-core#3446