### PR TITLE
Add logger configuration for `ItemStateUpdatedEvent` & `GroupStateUpdatedEvent`

### DIFF
--- a/launch/app/runtime/log4j2.xml
+++ b/launch/app/runtime/log4j2.xml
@@ -65,6 +65,7 @@
 		<Logger level="${env:logger.misc3.level:-DEBUG}" name="${env:logger.misc3.name:-override.me}"/>
 
 		<Logger level="ERROR" name="openhab.event.ItemStateEvent"/>
+		<Logger level="ERROR" name="openhab.event.ItemStateUpdatedEvent"/>
 		<Logger level="ERROR" name="openhab.event.ItemAddedEvent"/>
 		<Logger level="ERROR" name="openhab.event.ItemRemovedEvent"/>
 		<Logger level="ERROR" name="openhab.event.ItemChannelLinkAddedEvent"/>

--- a/launch/app/runtime/log4j2.xml
+++ b/launch/app/runtime/log4j2.xml
@@ -66,6 +66,7 @@
 
 		<Logger level="ERROR" name="openhab.event.ItemStateEvent"/>
 		<Logger level="ERROR" name="openhab.event.ItemStateUpdatedEvent"/>
+		<Logger level="ERROR" name="openhab.event.GroupStateUpdatedEvent"/>
 		<Logger level="ERROR" name="openhab.event.ItemAddedEvent"/>
 		<Logger level="ERROR" name="openhab.event.ItemRemovedEvent"/>
 		<Logger level="ERROR" name="openhab.event.ItemChannelLinkAddedEvent"/>


### PR DESCRIPTION
Refs https://github.com/openhab/openhab-core/pull/3141.

The newly added `ItemStateUpdated` & `GroupStateUpdatedEvent`s are  flooding my event logs and are not „hidden“ like other updated events, this adds the required logger configuration.