### PR TITLE
Remove obsolete addons from managed configuration

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -215,3 +215,15 @@ MOVE;$OPENHAB_USERDATA/jsondb/org.openhab.core.transform.TransformationConfigura
 REPLACE;,javascript;;$OPENHAB_USERDATA/config/org/openhab/addons.config
 REPLACE;javascript,;;$OPENHAB_USERDATA/config/org/openhab/addons.config
 REPLACE;javascript;;$OPENHAB_USERDATA/config/org/openhab/addons.config
+REPLACE;,cometvisu-php;;$OPENHAB_USERDATA/config/org/openhab/addons.config
+REPLACE;cometvisu-php,;;$OPENHAB_USERDATA/config/org/openhab/addons.config
+REPLACE;cometvisu-php;;$OPENHAB_USERDATA/config/org/openhab/addons.config
+REPLACE;,innogysmarthome;;$OPENHAB_USERDATA/config/org/openhab/addons.config
+REPLACE;innogysmarthome,;;$OPENHAB_USERDATA/config/org/openhab/addons.config
+REPLACE;innogysmarthome;;$OPENHAB_USERDATA/config/org/openhab/addons.config
+REPLACE;,imperihome;;$OPENHAB_USERDATA/config/org/openhab/addons.config
+REPLACE;imperihome,;;$OPENHAB_USERDATA/config/org/openhab/addons.config
+REPLACE;imperihome;;$OPENHAB_USERDATA/config/org/openhab/addons.config
+REPLACE;,darksky;;$OPENHAB_USERDATA/config/org/openhab/addons.config
+REPLACE;darksky,;;$OPENHAB_USERDATA/config/org/openhab/addons.config
+REPLACE;darksky;;$OPENHAB_USERDATA/config/org/openhab/addons.config

--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -210,3 +210,8 @@ DELETE;$OPENHAB_USERDATA/config/org/openhab/mqttbroker.config
 
 [3.4.0]
 MOVE;$OPENHAB_USERDATA/jsondb/org.openhab.core.transform.TransformationConfiguration.json;$OPENHAB_USERDATA/jsondb/org.openhab.core.transform.Transformation.json
+
+[4.0.0]
+REPLACE;,javascript;;$OPENHAB_USERDATA/config/org/openhab/addons.config
+REPLACE;javascript,;;$OPENHAB_USERDATA/config/org/openhab/addons.config
+REPLACE;javascript;;$OPENHAB_USERDATA/config/org/openhab/addons.config


### PR DESCRIPTION
It has been reported that the removal of the javascript transformation in openHAB 4 results in warnings because the add-on could not be found during installation. Since the add-on is no longer present, it does not show up in the UI and can't be uninstalled from there. This adds an update instruction to remove it from the addons.config.