### PR TITLE
Jetty `/static`: Set cache-control header & Enable gzip compression

### DIFF
--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -51,6 +51,7 @@
 						<New class="org.eclipse.jetty.server.handler.ResourceHandler">
 							<Set name="resourceBase"><SystemProperty name="openhab.conf" />/html</Set>
 							<Set name="directoriesListed">false</Set>
+							<Set name="cacheControl">max-age=31536000</Set>
 						</New>
 					</Set>
 				</New>
@@ -64,6 +65,7 @@
 				<Set name="includedPaths">
 					<Array type="java.lang.String">
 						<Item>/rest/*</Item>
+						<Item>/static/*</Item>
 					</Array>
 				</Set>
 				<Set name="includedMimeTypes">


### PR DESCRIPTION
This sets the cache-control header for what is served under `/static` to enable storage caching (very useful when serving images for UIs) and enables GZIP compression.