### PR TITLE
Remove standard package (default installation) as replaced by setup wizard

### DIFF
--- a/distributions/openhab/src/main/resources/conf/services/addons.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/addons.cfg
@@ -1,7 +1,7 @@
 # The installation package of this openHAB instance
 #
 # Valid options:
-#   - standard : Standard setup for normal use of openHAB with persistence (rrd4j) and additional UI add-ons (basic,habpanel).
+#   - standard : Standard setup for normal use of openHAB with additional UI add-ons (basic,habpanel).
 #   - minimal  : Installation of core components without additional add-ons.
 #
 # Note: The add-ons in the installation package are only installed at the VERY FIRST START of openHAB

--- a/distributions/openhab/src/main/resources/conf/services/addons.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/addons.cfg
@@ -1,15 +1,3 @@
-# The installation package of this openHAB instance
-#
-# Valid options:
-#   - standard : Standard setup for normal use of openHAB with additional UI add-ons (basic,habpanel).
-#   - minimal  : Installation of core components without additional add-ons.
-#
-# Note: The add-ons in the installation package are only installed at the VERY FIRST START of openHAB
-# Note: If you want to specify your add-ons yourself through entries below, set the package to "minimal"
-# as otherwise your definition might be in conflict with what the installation package defines.
-#
-package = standard
-
 # Access Remote Add-on Repository
 # Defines whether the remote openHAB add-on repository should be used for browsing and installing add-ons. (default is true)
 #

--- a/features/distro/src/main/feature/feature.xml
+++ b/features/distro/src/main/feature/feature.xml
@@ -9,12 +9,4 @@
         <bundle>mvn:org.openhab.ui.bundles/org.openhab.ui.iconset.classic/${project.version}</bundle>
     </feature>
 
-    <feature name="openhab-package-standard" description="openHAB Standard Package" version="${project.version}">
-        <feature>openhab-runtime-base</feature>
-        <config name="org.openhab.addons" append="true">
-			package = standard
-			ui = basic,habpanel
-        </config>
-    </feature>
-
 </features>

--- a/features/distro/src/main/feature/feature.xml
+++ b/features/distro/src/main/feature/feature.xml
@@ -14,7 +14,6 @@
         <config name="org.openhab.addons" append="true">
 			package = standard
 			ui = basic,habpanel
-			persistence = rrd4j
         </config>
     </feature>
 


### PR DESCRIPTION
https://github.com/openhab/openhab-webui/issues/1659 & https://github.com/openhab/openhab-webui/pull/1908 added recommended addons to the setup wizard.
These will get installed on a new openHAB install if the user does not actively de-select them, so the standard package (default installation) can be removed from distro.

See also #1455.