### PR TITLE
Disable "Improved ZIP64 Extra Field Validation"

### DIFF
--- a/distributions/openhab/src/main/resources/bin/setenv
+++ b/distributions/openhab/src/main/resources/bin/setenv
@@ -103,6 +103,7 @@ export JAVA_OPTS="${JAVA_OPTS}
   -Dopenhab.logdir=${OPENHAB_LOGDIR}
   -Dfelix.cm.dir=${OPENHAB_USERDATA}/config
   -Djava.library.path=${OPENHAB_USERDATA}/tmp/lib
+  -Djdk.util.zip.disableZip64ExtraFieldValidation=true
   -Djetty.host=${HTTP_ADDRESS}
   -Djetty.http.compliance=RFC2616
   -Dorg.apache.cxf.osgi.http.transport.disable=true

--- a/distributions/openhab/src/main/resources/bin/setenv.bat
+++ b/distributions/openhab/src/main/resources/bin/setenv.bat
@@ -120,6 +120,7 @@ set JAVA_OPTS=%JAVA_OPTS% ^
   -Dopenhab.logdir=%OPENHAB_LOGDIR% ^
   -Dfelix.cm.dir=%OPENHAB_USERDATA%\config ^
   -Djava.library.path=%OPENHAB_USERDATA%\tmp\lib ^
+  -Djdk.util.zip.disableZip64ExtraFieldValidation=true ^
   -Djetty.host=%HTTP_ADDRESS% ^
   -Djetty.http.compliance=RFC2616 ^
   -Dorg.apache.cxf.osgi.http.transport.disable=true ^

--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -76,6 +76,7 @@ feature.openhab-model-runtime-all: \
 	bnd.identity;id='org.apache.servicemix.specs.jaxb-api-2.3'
 
 -runproperties: \
+	jdk.util.zip.disableZip64ExtraFieldValidation=true,\
 	felix.cm.dir=${.}/runtime/userdata/config,\
 	org.osgi.framework.bootdelegation="sun.misc",\
 	org.osgi.service.http.port=8080,\


### PR DESCRIPTION
The org.apache.aries.javax.jax.rs-api bundle contains geronimo-osgi-locator.jar as a library which seems to have an "Invalid CEN header". This causes big stacktraces on startup with recent JVMs (11.0.20+9, 17.0.8+9) that have "Improved ZIP64 Extra Field Validation" (JDK-8302483).

Closes openhab/openhab-core#3718