### PR TITLE
Make sure updated log4j2.xml configuration is used

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -128,6 +128,9 @@ DEFAULT;$OPENHAB_USERDATA/etc/org.ops4j.pax.logging.cfg
 [3.2.0]
 DEFAULT;$OPENHAB_USERDATA/etc/log4j2.xml
 
+[4.0.2]
+DEFAULT;$OPENHAB_USERDATA/etc/log4j2.xml
+
 [[POST]]
 [2.3.0]
 DELETE;$OPENHAB_USERDATA/etc/org.openhab.addons.cfg


### PR DESCRIPTION
This update command makes sure that log4j2.xml contains the changes of #1398 and #1517.