### PR TITLE
Remove redundant `-XX:+UseG1GC` JVM option

### DIFF
--- a/distributions/openhab/src/main/resources/bin/setenv
+++ b/distributions/openhab/src/main/resources/bin/setenv
@@ -114,17 +114,10 @@ export JAVA_OPTS="${JAVA_OPTS}
 #
 # set JVM options
 #
-ARCH=`uname -m`
 EXTRA_JAVA_OPTS_COMMON="
   -Djava.awt.headless=true
   -Dfile.encoding=UTF-8"
-EXTRA_JAVA_OPTS_ARCH=""
-case "$ARCH" in
-    *arm*) ;;
-  *aarch*) ;;
-        *) EXTRA_JAVA_OPTS_ARCH="-XX:+UseG1GC" ;;
-esac
-export EXTRA_JAVA_OPTS="${EXTRA_JAVA_OPTS_COMMON} ${EXTRA_JAVA_OPTS_ARCH} ${EXTRA_JAVA_OPTS}"
+export EXTRA_JAVA_OPTS="${EXTRA_JAVA_OPTS_COMMON} ${EXTRA_JAVA_OPTS}"
 export JAVA_NON_DEBUG_OPTS="-XX:-UsePerfData"
 
 

--- a/distributions/openhab/src/main/resources/bin/setenv.bat
+++ b/distributions/openhab/src/main/resources/bin/setenv.bat
@@ -129,8 +129,7 @@ set JAVA_OPTS=%JAVA_OPTS% ^
   -Dorg.osgi.service.http.port.secure=%HTTPS_PORT%
 
 :: set jvm options
-set EXTRA_JAVA_OPTS=-XX:+UseG1GC ^
-  -Djava.awt.headless=true ^
+set EXTRA_JAVA_OPTS=-Djava.awt.headless=true ^
   -Dfile.encoding=UTF-8 ^
   %EXTRA_JAVA_OPTS%
   


### PR DESCRIPTION
The G1 garbage collector is the default GC since Java 9, see:

https://www.oracle.com/java/technologies/javase/9-relnotes.html#JDK-8081607