### PR TITLE
Reminder on how to increase webclient threads

### DIFF
--- a/distributions/openhab/src/main/resources/conf/services/runtime.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/runtime.cfg
@@ -275,6 +275,8 @@
 #
 #org.openhab.inbox:autoApprove=false
 
+################################## WEBCLIENT ###################################
+
 # For installations on higher end systems with many cores, increasing number of webclient threads
 # may be necessary. Usually, this is reported with "Insufficient configured threads" in the logs.
 #

--- a/distributions/openhab/src/main/resources/conf/services/runtime.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/runtime.cfg
@@ -275,3 +275,10 @@
 #
 #org.openhab.inbox:autoApprove=false
 
+# For installations on higher end systems with many cores, increasing number of webclient threads
+# may be necessary. Usually, this is reported with "Insufficient configured threads" in the logs.
+#
+# org.openhab.webclient:minThreadsShared = 20
+# org.openhab.webclient:maxThreadsShared = 80
+# org.openhab.webclient:minThreadsCustom = 20
+# org.openhab.webclient:maxThreadsCustom = 40


### PR DESCRIPTION
Every so often, increasing the number of webclient threads may become necessary, especially on dockerized systems with higher number of cores. This is a reminder for people on how to perform this.

See:
- https://community.openhab.org/search?q=webclient%20threads
- https://community.openhab.org/t/system-settings-for-other-hardware-platforms-then-pi/76787
-  https://community.openhab.org/t/fix-for-jetty-error-when-running-on-host-with-many-cores/57449

Related to https://github.com/openhab/openhab-addons/pull/15442
