### PR TITLE
Blacklist Karaf related bundles in Demo App

### DIFF
--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -92,6 +92,10 @@ feature.openhab-model-runtime-all: \
 -runblacklist: \
 	bnd.identity;id='jakarta.ws.rs-api',\
 	bnd.identity;id='org.apache.aries.jpa.container',\
+	bnd.identity;id='org.apache.karaf.kar.core',\
+	bnd.identity;id='org.openhab.core.addon.marketplace.karaf',\
+	bnd.identity;id='org.openhab.core.io.console.karaf',\
+	bnd.identity;id='org.openhab.core.karaf',\
 	bnd.identity;id='org.openhab.core.test',\
 	bnd.identity;id='osgi.annotation',\
 	bnd.identity;id='osgi.cmpn',\


### PR DESCRIPTION
This will protect developers from themselves in case they try to add Karaf related bundles to the Demo App.

Inspired by this [community topic](https://community.openhab.org/t/eclipse-via-eclipse-installer-adding-binding-fails-with-org-apache-karaf-kar-core-version-4-4-3/149382?u=wborn)