### PR TITLE
Remove Bountysource badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![GitHub Actions Build Status](https://github.com/openhab/openhab-distro/actions/workflows/ci-build.yml/badge.svg?branch=main)](https://github.com/openhab/openhab-distro/actions/workflows/ci-build.yml)
 [![Jenkins Build Status](https://ci.openhab.org/job/openHAB-Distribution/badge/icon)](https://ci.openhab.org/job/openHAB-Distribution/)
 [![EPL-2.0](https://img.shields.io/badge/license-EPL%202-green.svg)](https://opensource.org/licenses/EPL-2.0)
-[![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=28452711)](https://www.bountysource.com/teams/openhab/issues?tracker_ids=28452711)
 
 ## Introduction
 


### PR DESCRIPTION
It seems that Bountysource has been shut down as the website isn't reachable anymore and they don't respond to support mails.