### PR TITLE
Add suggestion finder parameters to addons.cfg

### DIFF
--- a/distributions/openhab/src/main/resources/conf/services/addons.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/addons.cfg
@@ -8,6 +8,14 @@
 #
 #includeIncompatible = false
 
+# The system can automatically suggest add-ons for installation using add-on finders.
+# If you don't want add-on suggestions from specific finders, you can disable the respective finders.
+# They are enabled by default.
+
+#suggestionFinderIp=true
+#suggestionFinderMdns=true
+#suggestionFinderUpnp=true
+
 # The add-on configuration in the lists below is applied EVERY TIME openHAB is started.
 # Add-ons installed using the UI that do not occur in the lists will be uninstalled each startup.
 # When lists are commented again any add-ons in the list remain installed and are not removed.

--- a/distributions/openhab/src/main/resources/conf/services/addons.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/addons.cfg
@@ -11,10 +11,10 @@
 # The system can automatically suggest add-ons for installation using add-on finders.
 # If you don't want add-on suggestions from specific finders, you can disable the respective finders.
 # They are enabled by default.
-
-#suggestionFinderIp=true
-#suggestionFinderMdns=true
-#suggestionFinderUpnp=true
+#
+#suggestionFinderIp = true
+#suggestionFinderMdns = true
+#suggestionFinderUpnp = true
 
 # The add-on configuration in the lists below is applied EVERY TIME openHAB is started.
 # Add-ons installed using the UI that do not occur in the lists will be uninstalled each startup.


### PR DESCRIPTION
Some of the add-on suggestion finders can be disable through the UI, or parameters in the addons.cfg file.

In this PR, these parameters are added (commented) in the configuration file.