### PR TITLE
Support Java 21

### DIFF
--- a/distributions/openhab/src/main/resources/bin/karaf
+++ b/distributions/openhab/src/main/resources/bin/karaf
@@ -160,7 +160,9 @@ init() {
     # Determine the JVM version and check that it is version 17
     checkJvmVersion
     if [ "${VERSION}" -ne "17" ]; then
-        die "JVM must be version 17. JVM version ${VERSION} is unsupported (JAVA_HOME=$JAVA_HOME)"
+        if [ "${VERSION}" -ne "21" ]; then
+            die "JVM must be version 17 or 21. JVM version ${VERSION} is unsupported (JAVA_HOME=$JAVA_HOME)"
+        fi
     fi
 
     # Check if a root instance is already running

--- a/distributions/openhab/src/main/resources/bin/karaf.bat
+++ b/distributions/openhab/src/main/resources/bin/karaf.bat
@@ -215,8 +215,10 @@ for /f tokens^=2-5^ delims^=.-_+^" %%j in ('"%JAVA%" -fullversion 2^>^&1') do (
 )
 
 if %JAVA_VERSION% NEQ 17 (
-    call :warn "JVM must be version 17. JVM version %JAVA_VERSION% is unsupported (JAVA_HOME=%JAVA_HOME%)"
-    goto END
+    if %JAVA_VERSION% NEQ 21 (
+        call :warn "JVM must be version 17 or 21. JVM version %JAVA_VERSION% is unsupported (JAVA_HOME=%JAVA_HOME%)"
+        goto END
+    )
 )
 
 if %JAVA_VERSION% GTR 8 (

--- a/launch/app/pom.xml
+++ b/launch/app/pom.xml
@@ -15,8 +15,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <oh.java.version>17</oh.java.version>
-    <maven.compiler.source>${oh.java.version}</maven.compiler.source>
-    <maven.compiler.target>${oh.java.version}</maven.compiler.target>
+    <maven.compiler.release>${oh.java.version}</maven.compiler.release>
     <bnd.version>7.0.0</bnd.version>
   </properties>
 
@@ -382,6 +381,13 @@
           </plugins>
         </pluginManagement>
       </build>
+    </profile>
+    <profile>
+      <id>j21</id>
+      <properties>
+        <oh.java.version>21</oh.java.version>
+        <maven.compiler.release>${oh.java.version}</maven.compiler.release>
+      </properties>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.13.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,10 +64,9 @@
     <karaf.version>4.4.5</karaf.version>
 
     <oh.java.version>17</oh.java.version>
-    <maven.compiler.source>${oh.java.version}</maven.compiler.source>
-    <maven.compiler.target>${oh.java.version}</maven.compiler.target>
+    <maven.compiler.release>${oh.java.version}</maven.compiler.release>
 
-    <sat.version>0.15.0</sat.version>
+    <sat.version>0.16.0</sat.version>
     <spotless.version>2.38.0</spotless.version>
     <!-- Eclipse Java formatter version 4.26+ does not check test files -->
     <spotless.eclipse.version>4.25</spotless.eclipse.version>
@@ -249,7 +248,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[17.0,18.0)</version>
+                  <version>[17.0,18.0),[21.0,22.0)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -317,6 +316,13 @@
         <build.number>Milestone Build</build.number>
         <online.repo>${oh.repo.releaseBaseUrl}/libs-milestone</online.repo>
         <pax.url.suffix></pax.url.suffix>
+      </properties>
+    </profile>
+    <profile>
+      <id>j21</id>
+      <properties>
+        <oh.java.version>21</oh.java.version>
+        <maven.compiler.release>${oh.java.version}</maven.compiler.release>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Allow for compiling with Java 21

* Support Java 17 and 21, default compilation to Java 17 class files
* Add profile "j21" to compile to Java 21 class files
* Upgrade SAT to 0.16.0
* Adapt Karaf scpipts to allow both Java 17 and 21

Refs:
#1590
openhab/openhab-core#4161
openhab/openhab-addons#16594