### PR TITLE
Update plugins

### DIFF
--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -87,7 +87,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.0</version>
           <dependencies>
             <dependency>
               <groupId>org.openhab.util</groupId>
@@ -103,7 +103,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>copy</id>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <maven.compiler.target>${oh.java.version}</maven.compiler.target>
 
     <sat.version>0.15.0</sat.version>
-    <spotless.version>2.38.0</spotless.version>
+    <spotless.version>2.43.0</spotless.version>
     <!-- Eclipse Java formatter version 4.26+ does not check test files -->
     <spotless.eclipse.version>4.25</spotless.eclipse.version>
     <spotless.eclipse.wtp.version>4.21.0</spotless.eclipse.wtp.version>
@@ -101,17 +101,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.4.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.7.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.13.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -126,12 +126,12 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>4.2</version>
+          <version>4.3</version>
           <configuration>
             <basedir>${basedir}</basedir>
             <quiet>false</quiet>
@@ -175,7 +175,7 @@
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.1</version>
           <configuration>
             <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
             <createBackupFile>false</createBackupFile>
@@ -248,6 +248,9 @@
             </goals>
             <configuration>
               <rules>
+                <requireMavenVersion>
+                  <version>3.6.3</version>
+                </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[17.0,18.0)</version>
                 </requireJavaVersion>


### PR DESCRIPTION
Update all plugins listed by
```mvn versions:display-plugin-updates -nsu  -B -Dversions.outputLineWidth=120 | grep -- '->' | sort -u ```

* set minimum Maven version to 3.6.3
* build-helper-maven-plugin, 3.4.0 to 3.5.0, see https://github.com/mojohaus/build-helper-maven-plugin/releases/tag/3.5.0
* license-maven-plugin, 4.2 to 4.3
* maven-assembly-plugin, 3.6.0 to 3.7.1, see https://github.com/apache/maven-assembly-plugin/releases
* maven-compiler-plugin, 3.11.0 to 3.13.0
* maven-enforcer-plugin, 3.4.0 to 3.4.1
* sortpom-maven-plugin, 3.3.0 to 3.4.1, see https://github.com/Ekryd/sortpom/releases
* spotless-maven-plugin, 2.38.0 to 2.43.0, see https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md