### PR TITLE
[openweathermap] Add One Call API version 2.5 shutdown warning

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -135,6 +135,7 @@ ALERT;AndroidTV Binding: The thing configuration of 'port' has been renamed and 
 ALERT;evcc Binding: Update to evcc API version 0.123.1 results in several new or updated channels. Existing Items will need to be adjusted.
 ALERT;ISM8 Binding: Most channels have changed and are now using Units of Measurements. Items must be adapted and the things must be recreated.
 ALERT;Jython Scripting: Default python lib path changed from "/automation/lib/python" to "/automation/jython/lib" and default python script path changed from "automation/jsr223" to "automation/jython". Just move your python scripts and libraries to new locations. The path "automation/jsr223" is still working, because it is used as a deprecated path for all automation add-ons.
+ALERT;OpenWeatherMap Binding: One Call API version 2.5 is to be shut down in June 2024. Read the binding's documentation for the migration process.
 
 [[PRE]]
 [2.2.0]


### PR DESCRIPTION
Refs https://github.com/openhab/openhab-addons/issues/16665.

/cc @holgerfriedrich @lolodomo 