### PR TITLE
Update persistence extension breaking change text

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -140,7 +140,7 @@ ALERT;JavaScript Scripting Automation: The 'Item.history' API has been replaced 
 ALERT;JavaScript Scripting Automation: Deprecated methods 'actions.ScriptExecution.createTimerWithArgument' (use 'createTimer'), 'cache.get', 'cache.put', 'cache.remove' & 'cache.exists' (use the private or shared cache) and fields 'state' (use 'receivedState') & 'receivedTrigger' (use 'receivedEvent') have been removed from the event object.
 ALERT;Jython Scripting: Default python lib path changed from "/automation/lib/python" to "/automation/jython/lib" and default python script path changed from "automation/jsr223" to "automation/jython". Just move your python scripts and libraries to new locations. The path "automation/jsr223" is still working, because it is used as a deprecated path for all automation add-ons.
 ALERT;OpenWeatherMap Binding: One Call API version 2.5 is to be shut down in June 2024. Read the binding's documentation for the migration process.
-ALERT;Persistence Extensions: "historicState" and evolutionRate" have been deprecated and replaced by "persistedState" and "evolutionRateSince". They will be removed in a future version. Methods may now return QuantityType instead of DecimalType. See documentation for details.
+ALERT;Persistence Extensions: "historicState" and evolutionRate" have been deprecated and replaced by "persistedState" and "evolutionRateSince". They will be removed in a future version. Methods may now return QuantityType instead of DecimalType. In Rules DSL, if you wish to do calculations without units, you may have to cast the results of the method to DecimalType explicitly. See documentation for details.
 ALERT;SMA Energy Meter: The Thing configuration has changed and now also requires the parameter "serialNumber". 
 
 [[PRE]]


### PR DESCRIPTION
We start seeing some problem descriptions in the forum with users using persistence extension actions with rules DSL. In certain cases there is a need to change the rule and add an explicit cast to DecimalType in the rule if one wishes to keep working without units, as State is not cast to a DecimalType automatically. See https://community.openhab.org/t/openhab-4-2-milestone-discussion/154316/140?u=mherwege and https://community.openhab.org/t/unknown-variable-or-command-in-rule/156191