### PR TITLE
Add config template for USB addon finder

### DIFF
--- a/distributions/openhab/src/main/resources/conf/services/addons.cfg
+++ b/distributions/openhab/src/main/resources/conf/services/addons.cfg
@@ -16,6 +16,7 @@
 #suggestionFinderMdns = true
 #suggestionFinderSddp = true
 #suggestionFinderUpnp = true
+#suggestionFinderUsb = true
 
 # The add-on configuration in the lists below is applied EVERY TIME openHAB is started.
 # Add-ons installed using the UI that do not occur in the lists will be uninstalled each startup.


### PR DESCRIPTION
This is already there for the other addon finders that can be enabled/disabled. This one was missing.