### PR TITLE
Archive released distro artifacts

### DIFF
--- a/launch/Jenkinsfile
+++ b/launch/Jenkinsfile
@@ -35,6 +35,10 @@ try {
     node {
         deleteDir()
         releaseComponent('openhab-distro', true, env.OH_BRANCH)
+
+        def releaseVersion = env.OH_RELEASE_VERSION
+        def distributions = 'openhab-distro/distributions'
+        archiveArtifacts artifacts: "${distributions}/openhab/target/openhab-${releaseVersion}.*, ${distributions}/openhab-addons/target/openhab-addons-${releaseVersion}.kar, ${distributions}/openhab-demo/target/openhab-demo-${releaseVersion}.*"
     }
 
     if(!env.SANDBOX?.toBoolean()) {


### PR DESCRIPTION
This will make it easier to test the artifacts generated by the pipeline.

See: https://ci.openhab.org/view/Sandbox/job/sandbox-openhab4-release/