### PR TITLE
Update update.lst with alert for deprecated electroluxair binding

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -283,3 +283,6 @@ REPLACE;porcupineks;;$OPENHAB_USERDATA/config/org/openhab/addons.config
 
 [4.2.0]
 DELETE;$OPENHAB_USERDATA/logs/audit.log
+
+[4.3.0]
+ALERT;ElectroluxAir binding: The binding has been removed since the Electrolux Delta API has been discontinued.

--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -148,9 +148,9 @@ ALERT;Transformations: NULL and UNDEF item states are now passed to any defined 
 ALERT;Transformations-MAP: "-" entry defined in a MAP file is no more used by sitemap UIs when the item state is NULL or UNDEF. You can now define "NULL" and "UNDEF" entries to map these 2 particular states or rely as before on the definition of a default mapping to map anything that has no entry in your file including NULL and UNDEF.
 
 [4.3.0]
+ALERT;ElectroluxAir binding: The binding has been removed since the Electrolux Delta API has been discontinued.
 ALERT;JavaScript Automation: The isJsInstanceOfJavaType method of the utils namespace has been removed. Use JavaScript's instanceof operator instead.
 ALERT;Pentair Binding: EasyTouch thing has been renamed to more generic Controller and all channels have been organized into groups. You will need to reconfigure your setup to the new thing structure.
-ALERT;ElectroluxAir binding: The binding has been removed since the Electrolux Delta API has been discontinued.
 
 [[PRE]]
 [2.2.0]

--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -150,6 +150,7 @@ ALERT;Transformations-MAP: "-" entry defined in a MAP file is no more used by si
 [4.3.0]
 ALERT;JavaScript Automation: The isJsInstanceOfJavaType method of the utils namespace has been removed. Use JavaScript's instanceof operator instead.
 ALERT;Pentair Binding: EasyTouch thing has been renamed to more generic Controller and all channels have been organized into groups. You will need to reconfigure your setup to the new thing structure.
+ALERT;ElectroluxAir binding: The binding has been removed since the Electrolux Delta API has been discontinued.
 
 [[PRE]]
 [2.2.0]
@@ -283,6 +284,3 @@ REPLACE;porcupineks;;$OPENHAB_USERDATA/config/org/openhab/addons.config
 
 [4.2.0]
 DELETE;$OPENHAB_USERDATA/logs/audit.log
-
-[4.3.0]
-ALERT;ElectroluxAir binding: The binding has been removed since the Electrolux Delta API has been discontinued.

--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -148,7 +148,7 @@ ALERT;Transformations: NULL and UNDEF item states are now passed to any defined 
 ALERT;Transformations-MAP: "-" entry defined in a MAP file is no more used by sitemap UIs when the item state is NULL or UNDEF. You can now define "NULL" and "UNDEF" entries to map these 2 particular states or rely as before on the definition of a default mapping to map anything that has no entry in your file including NULL and UNDEF.
 
 [4.3.0]
-ALERT;ElectroluxAir binding: The binding has been removed since the Electrolux Delta API has been discontinued.
+ALERT;ElectroluxAir Binding: The binding has been removed since the Electrolux Delta API has been discontinued.
 ALERT;JavaScript Automation: The isJsInstanceOfJavaType method of the utils namespace has been removed. Use JavaScript's instanceof operator instead.
 ALERT;Pentair Binding: EasyTouch thing has been renamed to more generic Controller and all channels have been organized into groups. You will need to reconfigure your setup to the new thing structure.
 


### PR DESCRIPTION
The ElectroluxAir binding is removed since the Electrolux Delta API has been discontinued.