### PR TITLE
meteoAlerte binding deprecated

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -151,9 +151,9 @@ ALERT;Transformations-MAP: "-" entry defined in a MAP file is no more used by si
 ALERT;CORE: The sendFrequency parameter for Slider and Colorpicker sitemap elements has been removed.
 ALERT;ElectroluxAir Binding: The binding has been removed since the Electrolux Delta API has been discontinued.
 ALERT;JavaScript Automation: The isJsInstanceOfJavaType method of the utils namespace has been removed. Use JavaScript's instanceof operator instead.
+ALERT;MeteoAlerte Binding: The underlying API stopped delivering data in May 2023. Binding has been removed and is now replaced by Météo France Binding based on a new API.
 ALERT;MQTT Binding: Newly discovered Home Assistant things will use simplified thing type and channel IDs. Delete and re-create your things to opt in to the new style. In subsequent a openHAB release, existing things will also convert to the new style.
 ALERT;Pentair Binding: EasyTouch thing has been renamed to more generic Controller and all channels have been organized into groups. You will need to reconfigure your setup to the new thing structure.
-ALERT;MeteoAlert Binding: The underlaying API stopped delivering data in May 2023. Binding has been removed and is now replaced by Météo France Binding based on a new API.
 
 [[PRE]]
 [2.2.0]

--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -153,6 +153,7 @@ ALERT;ElectroluxAir Binding: The binding has been removed since the Electrolux D
 ALERT;JavaScript Automation: The isJsInstanceOfJavaType method of the utils namespace has been removed. Use JavaScript's instanceof operator instead.
 ALERT;MQTT Binding: Newly discovered Home Assistant things will use simplified thing type and channel IDs. Delete and re-create your things to opt in to the new style. In subsequent a openHAB release, existing things will also convert to the new style.
 ALERT;Pentair Binding: EasyTouch thing has been renamed to more generic Controller and all channels have been organized into groups. You will need to reconfigure your setup to the new thing structure.
+ALERT;MeteoAlert Binding: The underlaying API stopped delivering data in May 2023. Binding has been removed and is now replaced by Météo France Binding based on a new API.
 
 [[PRE]]
 [2.2.0]


### PR DESCRIPTION
Add message for deprecation of MeteoAlert and its replacement by Meteo France