### PR TITLE
[mqtt.homeassistant] Dropped support for legacy schema vacuums.

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -152,7 +152,8 @@ ALERT;CORE: The sendFrequency parameter for Slider and Colorpicker sitemap eleme
 ALERT;ElectroluxAir Binding: The binding has been removed since the Electrolux Delta API has been discontinued.
 ALERT;JavaScript Automation: The isJsInstanceOfJavaType method of the utils namespace has been removed. Use JavaScript's instanceof operator instead.
 ALERT;MeteoAlerte Binding: The underlying API stopped delivering data in May 2023. Binding has been removed and is now replaced by Météo France Binding based on a new API.
-ALERT;MQTT Binding: Newly discovered Home Assistant things will use simplified thing type and channel IDs. Delete and re-create your things to opt in to the new style. In subsequent a openHAB release, existing things will also convert to the new style.
+ALERT;MQTT Binding (Home Assistant): Thing types and channel IDs have been significantly restructured and simplified. Delete and re-create your things to opt in to the new style. In a subsequent openHAB release, existing things will also convert to the new style.
+ALERT;MQTT Binding (Home Assistant): Legacy schema vacuums are no longer supported.
 ALERT;Pentair Binding: EasyTouch thing has been renamed to more generic Controller and all channels have been organized into groups. You will need to reconfigure your setup to the new thing structure.
 
 [[PRE]]


### PR DESCRIPTION
See https://github.com/openhab/openhab-addons/pull/17617

Also reworded previous Home Assistant alert to reference the wider scope of work that has been performed.