### PR TITLE
Add note about `DateTimeType` method deprecations

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -149,6 +149,7 @@ ALERT;Transformations-MAP: "-" entry defined in a MAP file is no more used by si
 
 [4.3.0]
 ALERT;CORE: The sendFrequency parameter for Slider and Colorpicker sitemap elements has been removed.
+ALERT;CORE: The DateTimeType methods toZone(zone), toLocaleZone() and getZonedDateTime() have been deprecated. They will be removed in a future version. getZonedDateTime(ZoneId) or getInstant() can be used as replacements for getZonedDateTime().
 ALERT;ElectroluxAir Binding: The binding has been removed since the Electrolux Delta API has been discontinued.
 ALERT;JavaScript Automation: The isJsInstanceOfJavaType method of the utils namespace has been removed. Use JavaScript's instanceof operator instead.
 ALERT;MeteoAlerte Binding: The underlying API stopped delivering data in May 2023. Binding has been removed and is now replaced by Météo France Binding based on a new API.


### PR DESCRIPTION
Related to openhab/openhab-core#3583
See also https://community.openhab.org/t/the-method-getzoneddatetime-from-the-type-datetimetype-is-deprecated/160763