### PR TITLE
Revert LinkedTransferQueue high CPU usage workaround

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/org.jupnp.cfg
+++ b/distributions/openhab/src/main/resources/userdata/etc/org.jupnp.cfg
@@ -1,4 +1,3 @@
-autoEnable=false
 multicastResponsePort=0
 asyncThreadPoolSize=30
 threadPoolSize=15

--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -242,7 +242,6 @@ feature.openhab-model-runtime-all: \
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
 	uom-lib-common;version='[2.2.0,2.2.1)',\
 	xstream;version='[1.4.21,1.4.22)',\
-	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
 	org.openhab.core;version='[5.0.0,5.0.1)',\
 	org.openhab.core.addon;version='[5.0.0,5.0.1)',\
 	org.openhab.core.addon.eclipse;version='[5.0.0,5.0.1)',\

--- a/launch/app/runtime/services.cfg
+++ b/launch/app/runtime/services.cfg
@@ -24,6 +24,5 @@ startlevel:50=ruleengine:start
 startlevel:70=dsl:sitemap
 startlevel:80=things:handler
 
-org.jupnp:autoEnable=false
 org.jupnp:threadPoolSize=20
 org.ops4j.pax.logging:org.ops4j.pax.logging.log4j2.config.file=../../../../runtime/log4j2.xml


### PR DESCRIPTION
Reverts the workaround (https://github.com/openhab/openhab-distro/pull/1636) that was introduced for [JDK-8301341](https://bugs.openjdk.org/browse/JDK-8301341) because it is fixed in OpenJDK 21 (https://github.com/openjdk/jdk/pull/14317).

Related to openhab/openhab-core#4499