### PR TITLE
Add entry in update.lst for latest guntamatic binding changes

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -158,7 +158,7 @@ ALERT;MQTT Binding (Home Assistant): Legacy schema vacuums are no longer support
 ALERT;Pentair Binding: EasyTouch thing has been renamed to more generic Controller and all channels have been organized into groups. You will need to reconfigure your setup to the new thing structure.
 
 [5.0.0]
-ALERT;Guntamatic Binding: Dynamic channels have now an index prefix to allow multiple channels with the same description. Re-connect changed and new channels to items.
+ALERT;Guntamatic Binding: Binding uses channel groups and the dynamic status channels use an index prefix to allow multiple channels with the same description. Re-connect changed and new channels to items.
 
 [[PRE]]
 [2.2.0]

--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -157,6 +157,9 @@ ALERT;MQTT Binding (Home Assistant): Thing types and channel IDs have been signi
 ALERT;MQTT Binding (Home Assistant): Legacy schema vacuums are no longer supported.
 ALERT;Pentair Binding: EasyTouch thing has been renamed to more generic Controller and all channels have been organized into groups. You will need to reconfigure your setup to the new thing structure.
 
+[5.0.0]
+ALERT;Guntamatic Binding: Dynamic channels have now an index prefix to allow multiple channels with the same description. Re-connect changed and new channels to items.
+
 [[PRE]]
 [2.2.0]
 DEFAULT;$OPENHAB_USERDATA/etc/org.ops4j.pax.logging.cfg


### PR DESCRIPTION
[5.0.0]
ALERT;Guntamatic Binding: Dynamic channels have now an index prefix to allow multiple channels with the same description. Re-connect changed and new channels to items.

https://github.com/openhab/openhab-addons/pull/17901