### PR TITLE
Enable HTTP/2 for HTTPS

### DIFF
--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -79,10 +79,10 @@
 		</Arg>
 	</Call>
 
-	<New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+	<New id="http2Config" class="org.eclipse.jetty.server.HttpConfiguration">
 		<Set name="secureScheme">https</Set>
 		<Set name="securePort">
-			<Property name="org.osgi.service.http.port.secure" default="8443" />
+			<Property name="org.osgi.service.http2.port.secure" default="8443" />
 		</Set>
 		<Set name="outputBufferSize">32768</Set>
 		<Set name="requestHeaderSize">8192</Set>
@@ -139,16 +139,21 @@
 					<Array type="org.eclipse.jetty.server.ConnectionFactory">
 						<Item>
 							<New class="org.eclipse.jetty.server.SslConnectionFactory">
-								<Arg name="next">http/1.1</Arg>
 								<Arg name="sslContextFactory">
 									<Ref refid="sslContextFactory" />
 								</Arg>
+								<Arg name="next">alpn</Arg>
 							</New>
 						</Item>
 						<Item>
-							<New class="org.eclipse.jetty.server.HttpConnectionFactory">
+							<New class="org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory">
+								<Arg>h2</Arg>
+							</New>
+						</Item>
+						<Item>
+							<New class="org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory">
 								<Arg name="config">
-									<Ref refid="httpConfig" />
+									<Ref refid="http2Config" />
 								</Arg>
 							</New>
 						</Item>

--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -79,10 +79,10 @@
 		</Arg>
 	</Call>
 
-	<New id="http2Config" class="org.eclipse.jetty.server.HttpConfiguration">
+	<New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
 		<Set name="secureScheme">https</Set>
 		<Set name="securePort">
-			<Property name="org.osgi.service.http2.port.secure" default="8443" />
+			<Property name="org.osgi.service.http.port.secure" default="8443" />
 		</Set>
 		<Set name="outputBufferSize">32768</Set>
 		<Set name="requestHeaderSize">8192</Set>
@@ -153,7 +153,7 @@
 						<Item>
 							<New class="org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory">
 								<Arg name="config">
-									<Ref refid="http2Config" />
+									<Ref refid="httpConfig" />
 								</Arg>
 							</New>
 						</Item>

--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -186,6 +186,7 @@ feature.openhab-model-runtime-all: \
 	org.eclipse.equinox.event;version='[1.6.200,1.6.201)',\
 	org.eclipse.equinox.metatype;version='[1.4.500,1.4.501)',\
 	org.eclipse.jetty.alpn.client;version='[9.4.54,9.4.55)',\
+	org.eclipse.jetty.alpn.server;version='[9.4.54,9.4.55)',\
 	org.eclipse.jetty.client;version='[9.4.54,9.4.55)',\
 	org.eclipse.jetty.http;version='[9.4.54,9.4.55)',\
 	org.eclipse.jetty.http2.client;version='[9.4.54,9.4.55)',\


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-core/pull/4526.