### PR TITLE
Revert bndrun change from #1711

### DIFF
--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -186,7 +186,6 @@ feature.openhab-model-runtime-all: \
 	org.eclipse.equinox.event;version='[1.6.200,1.6.201)',\
 	org.eclipse.equinox.metatype;version='[1.4.500,1.4.501)',\
 	org.eclipse.jetty.alpn.client;version='[9.4.54,9.4.55)',\
-	org.eclipse.jetty.alpn.server;version='[9.4.54,9.4.55)',\
 	org.eclipse.jetty.client;version='[9.4.54,9.4.55)',\
 	org.eclipse.jetty.http;version='[9.4.54,9.4.55)',\
 	org.eclipse.jetty.http2.client;version='[9.4.54,9.4.55)',\


### PR DESCRIPTION
See https://github.com/openhab/openhab-distro/pull/1711#discussion_r1898972226. This change is not needed, the demo app starts fine without it.