### PR TITLE
Upgrade plugins

### DIFF
--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -87,7 +87,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.5.0</version>
           <dependencies>
             <dependency>
               <groupId>org.openhab.util</groupId>
@@ -103,7 +103,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.8.1</version>
         <executions>
           <execution>
             <id>copy</id>

--- a/launch/app/pom.xml
+++ b/launch/app/pom.xml
@@ -218,13 +218,13 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.5.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>3.1.3</version>
         </plugin>
 
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -115,7 +115,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.3</version>
           <configuration>
             <!-- Workaround for build errors when using feature packaging and enableGeneration=true -->
             <!-- with the karaf-maven-plugin, see: https://issues.apache.org/jira/browse/KARAF-7734 -->
@@ -125,12 +125,12 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>4.3</version>
+          <version>4.6</version>
           <configuration>
             <basedir>${basedir}</basedir>
             <quiet>false</quiet>
@@ -174,7 +174,7 @@
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>4.0.0</version>
           <configuration>
             <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
             <createBackupFile>false</createBackupFile>


### PR DESCRIPTION
* sortpom-maven-plugin to 4.0.0 (breaking change) https://github.com/Ekryd/sortpom?tab=readme-ov-file#news
* maven-dependency-plugin to 3.8.1 https://github.com/apache/maven-dependency-plugin/releases
* exec-maven-plugin to 3.5.0 https://github.com/mojohaus/exec-maven-plugin/releases
* maven-enforcer-plugin to 3.5.0 https://github.com/apache/maven-enforcer/releases
* maven-install-plugin to 3.1.3 https://github.com/apache/maven-install-plugin/releases
* license-maven-plugin to 4.6 https://github.com/mathieucarbou/license-maven-plugin/releases
* build-helper-maven-plugin to 3.6.0 https://github.com/mojohaus/build-helper-maven-plugin/releases