### PR TITLE
Start license headers with `/*` instead of `/**`

### DIFF
--- a/distributions/openhab/merge-addon-info.groovy
+++ b/distributions/openhab/merge-addon-info.groovy
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/pom.xml
+++ b/pom.xml
@@ -138,8 +138,6 @@
             <strictCheck>true</strictCheck>
             <aggregate>true</aggregate>
             <mapping>
-              <groovy>JAVADOC_STYLE</groovy>
-              <java>JAVADOC_STYLE</java>
               <xml>xml-header-style</xml>
             </mapping>
             <useDefaultExcludes>true</useDefaultExcludes>


### PR DESCRIPTION
Prevents JavaDoc tooling issues because these tools check comments starting with `/**`.

Depends on #1717