### PR TITLE
Set OPENHAB_CONF envvar for upgradetool

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update
+++ b/distributions/openhab/src/main/resources/bin/update
@@ -358,6 +358,7 @@ chown -R "$FileOwner:$FileGroup" "$WorkingDir"
 ## Start the upgrade tool
 echo "Starting JSON database update..."
 export OPENHAB_USERDATA="$OPENHAB_USERDATA"
+export OPENHAB_CONF="$OPENHAB_CONF"
 java -jar "$WorkingDir/runtime/bin/upgradetool.jar" || {
   echo "Update tool failed, please check the openHAB website (www.openhab.org) for manual update instructions." >&2
   exit 1


### PR DESCRIPTION
This will be needed by the upgradetool to perform upgrades on files in $OPENHAB_CONF
Related PR: https://github.com/openhab/openhab-core/pull/4762
See https://github.com/openhab/openhab-core/issues/3666#issuecomment-2833277160
