### PR TITLE
Prepare for Maven 4

### DIFF
--- a/.mvn/README
+++ b/.mvn/README
@@ -1,0 +1,1 @@
+required by Maven 4 to detect root dir; adding root=true to pom is not compatible with Maven 3

--- a/distributions/openhab-addons/pom.xml
+++ b/distributions/openhab-addons/pom.xml
@@ -49,6 +49,22 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.3.1</version>
+        <configuration>
+          <escapeString>\</escapeString>
+        </configuration>
+        <executions>
+          <execution>
+            <id>process-resources</id>
+            <goals>
+              <goal>resources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
         <extensions>true</extensions>

--- a/distributions/openhab-addons/pom.xml
+++ b/distributions/openhab-addons/pom.xml
@@ -52,17 +52,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.3.1</version>
-        <configuration>
-          <escapeString>\</escapeString>
-        </configuration>
-        <executions>
-          <execution>
-            <id>process-resources</id>
-            <goals>
-              <goal>resources</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.karaf.tooling</groupId>

--- a/features/distro-kar/pom.xml
+++ b/features/distro-kar/pom.xml
@@ -32,17 +32,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.3.1</version>
-        <configuration>
-          <escapeString>\</escapeString>
-        </configuration>
-        <executions>
-          <execution>
-            <id>process-resources</id>
-            <goals>
-              <goal>resources</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.karaf.tooling</groupId>

--- a/features/distro-kar/pom.xml
+++ b/features/distro-kar/pom.xml
@@ -29,6 +29,22 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.3.1</version>
+        <configuration>
+          <escapeString>\</escapeString>
+        </configuration>
+        <executions>
+          <execution>
+            <id>process-resources</id>
+            <goals>
+              <goal>resources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.karaf.tooling</groupId>
         <artifactId>karaf-maven-plugin</artifactId>
         <extensions>true</extensions>


### PR DESCRIPTION
* Add a root marker to top level directory

This suppresses the warning about missing top level directory marker during build with Maven 4.
The approach to add .mvn dir is the option to do it which does not impact our standard builds with Maven 3.

* Add missing plugin to avoid warning

This did not show up in the other repos, but gave a warning in distro.
Hopefully adding the plugins does not have side effects.
What I had seen is that with config (my first commit), `verify` executes the plugin twice. This does not happen if it is included without config.