### PR TITLE
Create Maven "dev" profile

### DIFF
--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -280,4 +280,48 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>dev</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-clean-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>delete-runtime</id>
+                <goals>
+                  <goal>clean</goal>
+                </goals>
+                <phase>initialize</phase>
+                <configuration>
+                  <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                  <filesets>
+                    <fileset>
+                      <directory>target/${project.artifactId}-${project.version}/runtime</directory>
+                    </fileset>
+                  </filesets>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>archive</id>
+                <configuration>
+                  <formats>
+                    <format>dir</format>
+                  </formats>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/distributions/pom.xml
+++ b/distributions/pom.xml
@@ -15,11 +15,25 @@
 
   <name>openHAB Distributions</name>
 
-  <modules>
-    <module>openhab-addons</module>
-    <module>openhab-demo</module>
-    <module>openhab</module>
-    <module>openhab-verify</module>
-  </modules>
+  <profiles>
+    <profile>
+      <id>dev</id>
+      <modules>
+        <module>openhab</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>openhab-addons</module>
+        <module>openhab-demo</module>
+        <module>openhab</module>
+        <module>openhab-verify</module>
+      </modules>
+    </profile>
+  </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,14 @@
         <pax.url.suffix/>
       </properties>
     </profile>
+    <profile>
+      <id>dev</id>
+      <properties>
+        <build.number>- development build -</build.number>
+        <online.repo>${oh.repo.releaseBaseUrl}/libs-snapshot</online.repo>
+        <pax.url.suffix>@snapshots</pax.url.suffix>
+      </properties>
+    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
While the "demo app" is sufficient for debug and testing is most cases, there are times when running "full Karaf" is necessary to get a proper understanding of how things work. I've created a Maven "dev" profile that makes it easier to get a local Karaf installation of OH up and running from locally developed code, which can be used both for testing and debugging.

The "dev" profile modifies the Maven build so that only the "openhab" module is built, and it builds to a folder instead of an archive. Each subsequent build will delete the "runtime" folder inside the built folder, so that subsequent builds can be done without "clean", allowing the configuration of the "OH installation" to persist across rebuilds. It can't be used with "mvn install", use "mvn package -Pdev" instead. The built folder is a ready to start OH installation, use "start_debug" if you want to connect a debugger.

More information can be found [here](https://community.openhab.org/t/how-to-make-a-local-snapshot-build/164298/3).