### PR TITLE
Use gmavenplus-plugin

### DIFF
--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -166,14 +166,14 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>groovy-maven-plugin</artifactId>
-        <version>2.1.1</version>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>4.2.0</version>
         <dependencies>
           <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>4.0.13</version>
+            <version>4.0.27</version>
             <type>pom</type>
           </dependency>
         </dependencies>
@@ -184,7 +184,9 @@
             </goals>
             <phase>process-resources</phase>
             <configuration>
-              <source>${project.basedir}/merge-addon-info.groovy</source>
+              <scripts>
+                <script>${project.basedir}/merge-addon-info.groovy</script>
+              </scripts>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
* Replace groovy-maven-plugin by gmavenplus-plugin
* Upgrade groovy-all from 4.0.13 to 4.0.27

groovy-maven-plugin has not been updated for over 5 years, see https://mvnrepository.com/artifact/org.codehaus.gmaven/groovy-maven-plugin/2.1.1.

We use Groovy to generate the merged addons xml file. I checked that this file is still generated properly.