### PR TITLE
[shelly] Add update notification on breaking change

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -164,10 +164,13 @@ ALERT;CORE: Persistence alias functionality has been improved, allowing defining
 ALERT;Automower Binding: Implementation of complete automower API causes several channels to be removed, changed or added. New channels will need to be linked, existing items need to be adjusted.
 ALERT;Guntamatic Binding: The Binding now uses channel groups and the dynamic status channels now have an index prefix to allow multiple channels with the same description. Existing Items will need to be adjusted.
 ALERT;Juicenet Binding: The Binding has been removed due to removal of public API. Suggested alternative is to use https://github.com/JuiceRescue/juicepassproxy with the mqtt.homeasssistent binding.
+ALERT;Jython Automation: Transformation service name is renamed from "PY" to "JYTHONPY". "PY" is now used for transformations of the new Python Automation add-on.
+ALERT;Linky Binding : The Linky binding was refactored to add new functionalities. You now need a bridge device for the Linky binding to work. See Readme.md for detailed upgrade instructions.
 ALERT;MQTT Binding (Home Assistant): Thing types and channel IDs for things created prior to 4.3.0 have been significantly restructured and simplified. Items will need to be re-linked. Delete and re-create your Things to also have a simplified Thing Type ID in your Thing IDs.
 ALERT;MQTT Binding (Home Assistant): All scene components on a device are now exposed as a single String channel, with the scene name or object ID as its value. Existing Items and rules will need to be re-worked.
 ALERT;MQTT Binding (Home Assistant): Devices that use custom payloads or states now have that abstracted, so users should only use the default payloads. Rules and UIs may need to be updated for some devices.
-ALERT;Jython Automation: Transformation service name is renamed from "PY" to "JYTHONPY". "PY" is now used for transformations of the new Python Automation add-on.
+ALERT;Teslascope Binding: The Teslascope binding was refactored in order to support discovery. You now need a bridge device for the Teslascope binding to work.
+ALERT;Semantic Tags: Some Point tags reclassified as Properties; list of Point / Property / Equipment tags increased (so custom tags may now be semantic); tag validation is stricter. You may see validation warnings in the log, Items moved to another place in the UI, or other unexpected behavior.
 ALERT;Shelly Binding: Thing type shellypro2-relay was renamed to shellypro2. Delete the existing thing and re-discover the device.
 
 [[PRE]]


### PR DESCRIPTION
Shelly binding 5.0.0 will include a breaking change:
The thing type shellypro2-relay was renamed to shellypro2
The user has to delete the existing thing and re-discover the device.

Compare to openhab-addons PR #18902