### PR TITLE
[shelly] Update breaking changes for 5.1

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -170,6 +170,7 @@ ALERT;Linky Binding : The Linky binding was refactored to add new functionalitie
 ALERT;MQTT Binding (Home Assistant): Thing types and channel IDs for things created prior to 4.3.0 have been significantly restructured and simplified. Items will need to be re-linked. Delete and re-create your Things to also have a simplified Thing Type ID in your Thing IDs.
 ALERT;MQTT Binding (Home Assistant): All scene components on a device are now exposed as a single String channel, with the scene name or object ID as its value. Existing Items and rules will need to be re-worked.
 ALERT;MQTT Binding (Home Assistant): Devices that use custom payloads or states now have that abstracted, so users should only use the default payloads. Rules and UIs may need to be updated for some devices.
+ALERT;Shelly Binding: Thing type shellypro2-relay was renamed to shellypro2. Delete the existing things and re-discover the devices.
 ALERT;Teslascope Binding: The Teslascope binding was refactored in order to support discovery. You now need a bridge device for the Teslascope binding to work.
 ALERT;Tibber Binding: All channels have been renamed and restructured into groups. All items will need to be relinked to the new channel IDs.
 
@@ -190,7 +191,7 @@ ALERT;PythonScripting Automation: Changed parameter of "openhab.Registry.addItem
 ALERT;PythonScripting Automation: Replace "NotInitialisedException" with "NotFoundException" in "openhab.Registry.getItem, "openhab.Registry.removeItem", "openhab.Registry.getThing", "openhab.Registry.getChannel"
 ALERT;PythonScripting Automation: "openhab.Registry.getItemMetadata", "openhab.Registry.setItemMetadata" and "openhab.Registry.removeItemMetadata" replaced by "<Item>.getMetadata().get", "<Item>.getMetadata().set" and "<Item>.getMetadata().remove"
 ALERT;PythonScripting Automation: "openhab.Registry.safeItemName" move to "openhab.Item.buildSafeName"
-ALERT;Shelly Binding: Thing type shellypro2-relay was renamed to shellypro2, shellyplushtg3 to shellyplusht. Delete the existing things and re-discover the devices.
+ALERT;Shelly Binding: Thing type shellyplushtg3 was renamed to shellyplusht. Delete the existing things and re-discover the devices.
 ALERT;SMHI Binding: Due to updates to SMHI's API, the channel ids have changed. Measures have been taken to ensure backwards compatibility, but to avoid future issues all items need to be relinked to the new channels.
 
 [[PRE]]


### PR DESCRIPTION
Also thing type shellsplushtg3 was renamed to shellyplusht
relates to openhab/openhab-addons#18943