### PR TITLE
Update custom.properties

### DIFF
--- a/distributions/openhab/src/main/resources/userdata/etc/custom.properties
+++ b/distributions/openhab/src/main/resources/userdata/etc/custom.properties
@@ -5,6 +5,8 @@ karaf.lock.dir=${karaf.data}/tmp
 karaf.shutdown.port.file=${karaf.data}/tmp/port
 karaf.pid.file=${karaf.data}/tmp/karaf.pid
 
+org.osgi.framework.system.packages.extra=${org.osgi.framework.system.packages.extra},sun.security.pkcs11
+
 osgi.compatibility.bootdelegation = true
 
 felix.fileinstall.dir = ${karaf.data}/etc


### PR DESCRIPTION
This shows what i try to achieve, but obviously it fails. I would like to add this entry into the list for the config.properties. But it looks like that file is created on the fly and  we have no control over it?

So i started looking at the custom.properties file and tried to extend the exists set of values for this proeprty, but it fails. Any suggestions on how we can add this package ?
```
recursive variable reference: org.osgi.framework.system.packages.extra
Error occurred shutting down framework: java.lang.IllegalArgumentException: recursive variable reference: org.osgi.framework.system.packages.extra
```

Related to: https://github.com/openhab/openhab-addons/pull/18983
Related to: https://github.com/openhab/openhab-addons/pull/18986