### PR TITLE
Increase default max size for thingHandler thread pool

### DIFF
--- a/distributions/openhab/src/main/resources/runtime/services.cfg
+++ b/distributions/openhab/src/main/resources/runtime/services.cfg
@@ -11,7 +11,7 @@ folder:things=things
 # Configuration of thread pool sizes
 threadpool:discovery=5
 threadpool:safeCall=10
-threadpool:thingHandler=5
+threadpool:thingHandler=15
 
 # Start level definitions
 startlevel:20=dsl:items,managed:item,dsl:things,managed:thing,managed:itemchannellink,dsl:persist,managed:metadata


### PR DESCRIPTION
Changed from 5 to 15.

Related to discussion in openhab/openhab-addons#19125