### PR TITLE
Fix Eclipse IDE setup

### DIFF
--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2352,13 +2352,12 @@
       <requirement
           name="org.eclipse.m2e.logback.feature.feature.group"/>
       <requirement
-          name="org.eclipse.m2e.feature.feature.group"/>
-      <requirement
           name="org.eclipse.wst.jsdt.feature.feature.group"/>
       <requirement
           name="org.eclipse.wst.web_ui.feature.feature.group"/>
       <requirement
-          name="bndtools.m2e.feature.feature.group"/>
+          name="bndtools.m2e.feature.feature.group"
+		  versionRange="[7.0.0,7.1.0)"/>
       <requirement
           name="org.lastnpe.m2e.feature.feature.group"/>
       <requirement


### PR DESCRIPTION
Ever since bndtools 7.1.0 was released, OH's Eclipse setup has been broken. The problem has been identified, but they haven't released a patched version, so the fix won't arrive until 7.2.0. However, a snapshot version of 7.2.0 exists, but it has a different problem which still breaks things.

So, until this changes, it seems the best approach is to lock bndtools to 7.0.0 until a newer working version exists.

I made this several months ago, and no longer remember why `org.eclipse.m2e.feature.feature.group` was removed, but this has been tested by me and quite a few others and seems to work like it is. I had [a post on the forum](https://community.openhab.org/t/californium-removed/163625/78) that people have used to install Eclipse in the meanwhile, and as far as I know, this has resolved the problem for all that have used it. Now however, the links in the forum post are all dead (both to the setup file itself and to the screenshots explaining how to use it), so that's no longer an option, and I figure it's time to make this "temporary permanent".

See [this thread](https://community.openhab.org/t/osgi-resolve-gives-error/160641) for some of the related problems reported.