### PR TITLE
Add breaking change alerts for JS Scripting

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -178,6 +178,8 @@ ALERT;Tibber Binding: All channels have been renamed and restructured into group
 ALERT;Automower Binding: Implementation of Automower WebSocket API causes several channels to be removed, changed or added. New channels will need to be linked, existing items need to be adjusted.
 ALERT;evcc Binding: Restructured to modular things with auto-discovery of datapoints. You must reconfigure settings, recreate Things, and adjust Items as previous configurations are incompatible.
 ALERT;Freebox Binding: The binding has been removed from the distribution. You should consider migrating to the FreeboxOS binding.
+ALERT;JavaScript Automation: The event object in UI-based environments has been aligned with the file-based event object. Properties are now pure JavaScript types and property names have changed. Blockly users need to resave their scripts.
+ALERT;JavaScript Automation: Automatic injection of the openHAB JavaScript library now allows for more fine-grained control. It is recommended to manually import required namespaces from the openhab library in file-based scripts and transformations and disable automatic injection for file-based scripts and transformations.
 
 [[PRE]]
 [2.2.0]


### PR DESCRIPTION
- Warn about breaking change for UI event object. (In fact the existing code will in most cases continue to work, it will print deprecation warnings to the log.)
- Advise to manually import the library into file-based scripts and transformations and turn off auto-injection.

Signed-off-by: Florian Hotze <dev@florianhotze.com>