### PR TITLE
Fix repo list

### DIFF
--- a/launch/build.gradle
+++ b/launch/build.gradle
@@ -53,7 +53,8 @@ task buildChangelog {
         "milestone" : "${openHABMilestone}",
         "repos" : [
           [
-            "name" : "openhab-core",
+            "name" : "openhab-core"
+          ],[
             "name" : "openhab-distro"
           ]
         ]


### PR DESCRIPTION
This correctly includes openhab-core PRs in the release notes.