### PR TITLE
Update app.bndrun to include the provider preset in the demo app

### DIFF
--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -54,6 +54,7 @@ feature.openhab-model-runtime-all: \
 	bnd.identity;id='org.openhab.core.automation',\
 	bnd.identity;id='org.openhab.core.automation.module.media',\
 	bnd.identity;id='org.openhab.core.automation.module.script',\
+	bnd.identity;id='org.openhab.core.automation.module.script.providersupport',\
 	bnd.identity;id='org.openhab.core.automation.module.script.rulesupport',\
 	bnd.identity;id='org.openhab.core.automation.rest',\
 	bnd.identity;id='org.openhab.core.io.console.rfc147',\
@@ -249,6 +250,7 @@ feature.openhab-model-runtime-all: \
 	org.openhab.core.automation;version='[5.1.0,5.1.1)',\
 	org.openhab.core.automation.module.media;version='[5.1.0,5.1.1)',\
 	org.openhab.core.automation.module.script;version='[5.1.0,5.1.1)',\
+	org.openhab.core.automation.module.script.providersupport;version='[5.1.0,5.1.1)',\
 	org.openhab.core.automation.module.script.rulesupport;version='[5.1.0,5.1.1)',\
 	org.openhab.core.automation.rest;version='[5.1.0,5.1.1)',\
 	org.openhab.core.config.core;version='[5.1.0,5.1.1)',\


### PR DESCRIPTION
In all the JSR223 bundles, the 'provider' preset is the only missing provider when running a JSR223 script in the demo-app.
This PR enables the bundle responsible for adding the related presets in all JSR223 bindings.