### PR TITLE
[folderwatcher] Add warning about changed AzureBlob parameter

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -178,6 +178,7 @@ ALERT;Tibber Binding: All channels have been renamed and restructured into group
 ALERT;Allplay Binding: Due to limited usage and increasing maintenance issues, this binding has been removed.
 ALERT;Automower Binding: Restructured to modular things with auto-discovery of datapoints. New things and channels will need to be linked, existing items need to be adjusted.
 ALERT;evcc Binding: Restructured to modular things with auto-discovery of datapoints. You must reconfigure settings, recreate Things, and adjust Items as previous configurations are incompatible.
+ALERT;Folderwatcher Binding: A typo was corrected in the AzureBlob thing parameter containerPath. You may need to reconfigure this parameter.
 ALERT;Freebox Binding: The binding has been removed from the distribution. You should consider migrating to the FreeboxOS binding.
 ALERT:Guntamatic Binding: Channel ID spelling errors (such as `079-interuption-0` and `080-interuption-1`) have been corrected. You may need to update items linked to these channels.
 ALERT;JavaScript Automation: The event object in UI-based environments has been aligned with the file-based event object. Properties are now pure JavaScript types and property names have changed. Blockly users need to resave their scripts.


### PR DESCRIPTION
Corrected a typo in the AzureBlob thing parameter containerPath for the Folderwatcher Binding.