### PR TITLE
Fix mapdb.persist example with updated syntax

### DIFF
--- a/launch/app/runtime/conf/persistence/mapdb.persist
+++ b/launch/app/runtime/conf/persistence/mapdb.persist
@@ -1,7 +1,7 @@
-// persistence strategies have a name and a definition and are referred to in the "Items" section
+// Persistence strategies have a name and a definition and are referred to in the "Items" section,
+// everyChange, everyUpdate, restoreOnStartup and forecast strategies are predefined.
 Strategies {
-	// if no strategy is specified for an item entry below, the default list will be used
-	default = everyChange, restoreOnStartup
+    everyHour: "0 0 * * * ?"
 }
 
 /* 
@@ -10,6 +10,8 @@ Strategies {
  * item (excl. the group item itself).
  */
 Items {
-	// log demo number on every change
-	DemoNumber;
+	// persist demoNumber on every change, restore on startup
+	DemoNumber: strategy = everyChange, restoreOnStartup
+	// persist demoString every hour
+	DemoString: strategy = everyHour
 }


### PR DESCRIPTION
The demo configuration will generate an error when starting in Eclipse because the existing mapdb.persist file has not been adapted to the removal of the Default persistence services.
This PR fixes that issue.