### PR TITLE
update script: Apply file ownership for files created by upgradetool

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update
+++ b/distributions/openhab/src/main/resources/bin/update
@@ -363,6 +363,8 @@ java -jar "$WorkingDir/runtime/bin/upgradetool.jar" || {
   echo "Update tool failed, please check the openHAB website (www.openhab.org) for manual update instructions." >&2
   exit 1
 }
+# Apply file ownership for JSON database as upgradetool can create new files
+chown -R "$FileOwner:$FileGroup" "$OPENHAB_USERDATA/jsondb"
 echo "JSON database updated successfully."
 
 echo ""


### PR DESCRIPTION
See https://github.com/openhab/openhab-webui/pull/3123#issuecomment-3677830338.

Note: The PowerShell (.ps1) update script for Windows does not receive that change and IMO also doesn't need it, as the update script on Windows will be executed by the user - on Linux, it will likely be executed by root through the package manager.