### PR TITLE
Update license headers to 2026

### DIFF
--- a/distributions/openhab/merge-addon-info.groovy
+++ b/distributions/openhab/merge-addon-info.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025 Contributors to the openHAB project
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
             </mapping>
             <useDefaultExcludes>true</useDefaultExcludes>
             <properties>
-              <year>2025</year>
+              <year>2026</year>
             </properties>
             <encoding>UTF-8</encoding>
             <licenseSets>


### PR DESCRIPTION
Performed by `mvn license:format` after:
- Updating copyright year in configurations.

Verification:
```shell
$ grep -R "Copyright (c) 2010-2025 Contributors to the openHAB project"
$
```

Previous iterations: #1713