### PR TITLE
Update update.ps1

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.ps1
+++ b/distributions/openhab/src/main/resources/bin/update.ps1
@@ -637,10 +637,16 @@ Function Update-openHAB() {
         Write-Host -ForegroundColor Cyan "Creating backup directories in $TempBackupDir"
         DeleteIfExists $TempBackupDir $True
 
-        Write-Host -ForegroundColor Cyan "Copying directory conf, userdata and runtime to $TempBackupDirConf"
-        Copy-Item -Path $OHConf, $OHUserData, $OHRuntime -Destination $TempBackupDir -Recurse -Force -ErrorAction Stop
+        Write-Host -ForegroundColor Cyan "Copying directory conf, userdata and runtime to $TempBackupDir"
+        New-Item -Path $TempBackupDir -Name "conf" -ItemType "Directory"
+		Copy-Item -Path $OHConf -Destination $TempBackupDirConf -Recurse -Force -ErrorAction Stop
+		New-Item -Path $TempBackupDir -Name "userdata" -ItemType "Directory"
+		Copy-Item -Path $OHUserData -Destination $TempBackupDirUserData -Recurse -Force -ErrorAction Stop
+		New-Item -Path $TempBackupDir -Name "runtime" -ItemType "Directory"
+		Copy-Item -Path $OHRuntime -Destination $TempBackupDirRuntime -Recurse -Force -ErrorAction Stop
 
         Write-Host -ForegroundColor Cyan "Copying files from $OHDirectory to $TempBackupDirHome"
+        New-Item -Path $TempBackupDir -Name "home" -ItemType "Directory"
         Get-ChildItem $OHDirectory -File -ErrorAction Stop | Copy-Item -Destination $TempBackupDirHome -Force -ErrorAction Stop
 
     } catch {


### PR DESCRIPTION
More robust backup handling
The upgrade failed on Windows 10, because the files are copied to a file named "home" instead of a the directory home. Simmilar thing happend to conf/userdata/runtime
With the changes the process is more robust and with the correct folders it is able to restore the files later.
