### PR TITLE
Alert for removal of coronastats binding

### DIFF
--- a/distributions/openhab/src/main/resources/bin/update.lst
+++ b/distributions/openhab/src/main/resources/bin/update.lst
@@ -196,6 +196,9 @@ ALERT;PythonScripting Automation: "openhab.Registry.safeItemName" move to "openh
 ALERT;Shelly Binding: Thing type shellyplushtg3 was renamed to shellyplusht. Delete the existing things and re-discover the devices.
 ALERT;SMHI Binding: Due to updates to SMHI's API, the channel ids have changed. Measures have been taken to ensure backwards compatibility, but to avoid future issues all items need to be relinked to the new channels.
 
+[5.2.0]
+ALERT;Corona Stats Binding: Due to EOL of the website, this add-on has been removed.
+
 [[PRE]]
 [2.2.0]
 DEFAULT;$OPENHAB_USERDATA/etc/org.ops4j.pax.logging.cfg


### PR DESCRIPTION
coronastats binding will be removed
Refs: openhab/openhab-addons#20129