### PR TITLE
Upgrade Karaf to 4.4.10

### DIFF
--- a/distributions/openhab/src/main/resources/bin/karaf
+++ b/distributions/openhab/src/main/resources/bin/karaf
@@ -304,8 +304,8 @@ run() {
                 ${KARAF_EXEC} "${JAVA}" ${JAVA_OPTS} \
                     --add-reads=java.xml=java.logging \
                     --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED \
-                    --patch-module java.base="${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.locator-4.4.9.jar" \
-                    --patch-module java.xml="${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.java.xml-4.4.9.jar" \
+                    --patch-module java.base="${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.locator-4.4.10.jar" \
+                    --patch-module java.xml="${KARAF_HOME}/lib/endorsed/org.apache.karaf.specs.java.xml-4.4.10.jar" \
                     --add-opens java.base/java.security=ALL-UNNAMED \
                     --add-opens java.base/java.net=ALL-UNNAMED \
                     --add-opens java.base/java.lang=ALL-UNNAMED \

--- a/distributions/openhab/src/main/resources/bin/karaf.bat
+++ b/distributions/openhab/src/main/resources/bin/karaf.bat
@@ -24,8 +24,8 @@ set DIRNAME=%~dp0%
 set PROGNAME=%~nx0%
 set ARGS=%*
 
-rem enabling workaround for utf8 tables, chcp 65001
-rem TODO: remove when upgrading from 4.4.9 to 4.4.10 or 4.5.0
+rem cleanly display utf8 tables, chcp 65001
+rem this can be removed when fixed in jline
 chcp 65001 > nul
 rem as this is within the setlocal section, the change will be reverted on exit
 
@@ -417,8 +417,8 @@ if "%KARAF_PROFILER%" == "" goto :RUN
             "%JAVA%" %JAVA_OPTS% %OPTS% ^
                 --add-reads=java.xml=java.logging ^
                 --add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED ^
-                --patch-module java.base="%KARAF_HOME%\lib\endorsed\org.apache.karaf.specs.locator-4.4.9.jar" ^
-                --patch-module java.xml="%KARAF_HOME%\lib\endorsed\org.apache.karaf.specs.java.xml-4.4.9.jar" ^
+                --patch-module java.base="%KARAF_HOME%\lib\endorsed\org.apache.karaf.specs.locator-4.4.10.jar" ^
+                --patch-module java.xml="%KARAF_HOME%\lib\endorsed\org.apache.karaf.specs.java.xml-4.4.10.jar" ^
                 --add-opens java.base/java.security=ALL-UNNAMED ^
                 --add-opens java.base/java.net=ALL-UNNAMED ^
                 --add-opens java.base/java.lang=ALL-UNNAMED ^

--- a/launch/app/app.bndrun
+++ b/launch/app/app.bndrun
@@ -125,8 +125,8 @@ feature.openhab-model-runtime-all: \
 # done
 #
 -runbundles: \
-	org.ops4j.pax.logging.pax-logging-api;version='[2.3.0,2.3.1)',\
-	org.ops4j.pax.logging.pax-logging-log4j2;version='[2.3.0,2.3.1)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.3.2,2.3.3)',\
+	org.ops4j.pax.logging.pax-logging-log4j2;version='[2.3.2,2.3.3)',\
 	com.fasterxml.jackson.core.jackson-annotations;version='[2.21.0,2.21.1)',\
 	com.fasterxml.jackson.core.jackson-core;version='[2.21.0,2.21.1)',\
 	com.fasterxml.jackson.core.jackson-databind;version='[2.21.0,2.21.1)',\

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <ohc.version>5.2.0-SNAPSHOT</ohc.version>
     <oha.version>5.2.0-SNAPSHOT</oha.version>
 
-    <karaf.version>4.4.9</karaf.version>
+    <karaf.version>4.4.10</karaf.version>
 
     <oh.java.version>21</oh.java.version>
     <maven.compiler.release>${oh.java.version}</maven.compiler.release>
@@ -94,8 +94,7 @@
         <plugin>
           <groupId>org.apache.karaf.tooling</groupId>
           <artifactId>karaf-maven-plugin</artifactId>
-          <!-- TODO replace fixed version 4.4.8 by ${karaf.tooling.version} one karaf#2219 is contained in future release -->
-          <version>4.4.8</version>
+          <version>4.4.10</version>
           <extensions>true</extensions>
         </plugin>
         <plugin>


### PR DESCRIPTION
Upgrade Karaf from 4.4.9 to 4.4.10.
This includes upgrades for the following libraries:
* pax-logging from 2.3.1 to 2.3.2

Move workaround for jline issue in 4.4.9 on Windows platform to karaf.bat to stay in sync with upstream.

Depends on openhab/openhab-core#5353