### PR TITLE
gzip compress assets and images

### DIFF
--- a/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
+++ b/distributions/openhab/src/main/resources/runtime/etc/jetty.xml
@@ -64,15 +64,22 @@
 				<Set name="minGzipSize">1024</Set>
 				<Set name="includedPaths">
 					<Array type="java.lang.String">
+						<Item>/assets/*</Item>
+						<Item>/images/*</Item>
 						<Item>/rest/*</Item>
 						<Item>/static/*</Item>
 					</Array>
 				</Set>
 				<Set name="includedMimeTypes">
 					<Array type="java.lang.String">
+						<Item>application/javascript</Item>
 						<Item>application/json</Item>
+						<Item>image/svg+xml</Item>
+						<Item>text/css</Item>
 						<Item>text/html</Item>
+						<Item>text/javascript</Item>
 						<Item>text/plain</Item>
+						<Item>text/xml</Item>
 					</Array>
 				</Set>
 			</New>


### PR DESCRIPTION
This PR will enable gzip compression for `/assets/*` and `/images/*` with more mime types.
In the past the precompressed files where used, but this is currently broken and a deprecated Jetty feature.
So i does not make sense for me to fix using the precompressed files, as the support has been removed in Jetty 10+.

Before the 5 MB javascript was not compressed:
<img width="1794" height="126" alt="grafik" src="https://github.com/user-attachments/assets/0af88240-886c-4fdd-9ba4-e4ca32078d3e" />

Now the 5 MB file is compressed to 1.16 MB
<img width="1498" height="149" alt="grafik" src="https://github.com/user-attachments/assets/04c3dbc7-ffc8-431e-a920-91d232d6862e" />
 