### PR TITLE
Backup script: Fix exclusions not working & Include Piper/Vosk/Whisper dirs in full backup

### DIFF
--- a/distributions/openhab/src/main/resources/bin/backup
+++ b/distributions/openhab/src/main/resources/bin/backup
@@ -20,10 +20,8 @@ usage() {
    echo "that uses the Exec Binding, and a command like: openhab-cli backup --noninteractive"
    echo ""
    echo "A full backup must be done in interactive mode, and includes the tmp and cache directories"
-   echo "that are normally excluded."
-   echo ""
-   echo "Piper, Vosk & Whisper voice add-on directories are always excluded from backups."
-   echo "These directories contain big model files, which can be downloaded again."
+   echo "that are normally excluded. It also includes the Piper, Vosk & Whisper voice add-on directories"
+   echo "that are normally excluded due to the model size."
    echo ""
    echo "Backup directory: '$OPENHAB_BACKUPS'"
    echo "Set \$OPENHAB_BACKUPS to change the default backup directory."
@@ -202,14 +200,11 @@ if [ -z "$INCLUDE_CACHE" ]; then
       -and -not -path '*/whisper' \
     | xargs -I % cp -R % "$TempDir/userdata"
 else
-  # excludes: backup dir, Java heap/crash dumps, Piper/Vosk/Whisper model dirs
+  # excludes: backup dir, Java heap/crash dumps
   find "${OPENHAB_USERDATA:?}/"* -prune \
       -not -path "${OPENHAB_BACKUPS:?}" \
       -and -not -name '*.hprof' \
       -and -not -name 'hs_err_pid*' \
-      -and -not -path '*/piper' \
-      -and -not -path '*/vosk' \
-      -and -not -path '*/whisper' \
     | xargs -I % cp -R % "$TempDir/userdata"
 fi
 mkdir -p "$TempDir/conf"

--- a/distributions/openhab/src/main/resources/bin/backup
+++ b/distributions/openhab/src/main/resources/bin/backup
@@ -189,15 +189,28 @@ fi
 [ "$bInteractive"  = "1" ] && echo "Copying configuration to temporary folder..."
 mkdir -p "$TempDir/userdata"
 
-# shellcheck disable=SC2089
-DUMP_EXCLUDES="-not -name '*.hprof' -and -not -name 'hs_err_pid*'" # excludes Java heap dumps and crash dumps
-# shellcheck disable=SC2089
-VOICE_ADDON_EXCLUDES="-and -not -name '*/piper' -and -not -path '*/vosk' -and -not -path '*/whisper'" # excludes Piper, Vosk & Whisper directories due to containing big model files
-
 if [ -z "$INCLUDE_CACHE" ]; then
-  find "${OPENHAB_USERDATA:?}/"* -prune -not -path "${OPENHAB_BACKUPS:?}" -and -not -path '*/tmp' -and -not -path '*/cache' $DUMP_EXCLUDES $VOICE_ADDON_EXCLUDES | xargs -I % cp -R % "$TempDir/userdata"
+  # excludes: backup dir, tmp/cache dirs, Java heap/crash dumps, Piper/Vosk/Whisper model dirs
+  find "${OPENHAB_USERDATA:?}/"* -prune \
+      -not -path "${OPENHAB_BACKUPS:?}" \
+      -and -not -path '*/tmp' \
+      -and -not -path '*/cache' \
+      -and -not -name '*.hprof' \
+      -and -not -name 'hs_err_pid*' \
+      -and -not -path '*/piper' \
+      -and -not -path '*/vosk' \
+      -and -not -path '*/whisper' \
+    | xargs -I % cp -R % "$TempDir/userdata"
 else
-  find "${OPENHAB_USERDATA:?}/"* -prune -not -path "${OPENHAB_BACKUPS:?}" $DUMP_EXCLUDES $VOICE_ADDON_EXCLUDES | xargs -I % cp -R % "$TempDir/userdata"
+  # excludes: backup dir, Java heap/crash dumps, Piper/Vosk/Whisper model dirs
+  find "${OPENHAB_USERDATA:?}/"* -prune \
+      -not -path "${OPENHAB_BACKUPS:?}" \
+      -and -not -name '*.hprof' \
+      -and -not -name 'hs_err_pid*' \
+      -and -not -path '*/piper' \
+      -and -not -path '*/vosk' \
+      -and -not -path '*/whisper' \
+    | xargs -I % cp -R % "$TempDir/userdata"
 fi
 mkdir -p "$TempDir/conf"
 cp -a "${OPENHAB_CONF:?}/"*      "$TempDir/conf"


### PR DESCRIPTION
- The exclusions added in #1861 weren't working.
- Do not exclude Piper, Vosk & Whisper model dirs from full backup.