### PR TITLE
Adapt deployment URL specification

### DIFF
--- a/launch/Jenkinsfile
+++ b/launch/Jenkinsfile
@@ -86,10 +86,10 @@ def releaseOpenHabComponent(componentName, branch, releaseVersion, nextVersion, 
                     mvnOptionsMap["sandbox"] = "-P sandbox"
                 }
                 if(env.ALT_RELEASE_REPO_ID?.length() > 0) {
-                    mvnReleaseOptions += "-DaltDeploymentRepository=" + env.ALT_RELEASE_REPO_ID + '::default::' + env.ALT_RELEASE_REPO_URL
+                    mvnReleaseOptions += "-DaltDeploymentRepository=" + env.ALT_RELEASE_REPO_ID + '::' + env.ALT_RELEASE_REPO_URL
                 }
                 if(env.ALT_SNAPSHOT_REPO_ID?.length() > 0) {
-                    mvnSnapshotOptions += "-DaltDeploymentRepository=" + env.ALT_SNAPSHOT_REPO_ID + '::default::' + env.ALT_SNAPSHOT_REPO_URL
+                    mvnSnapshotOptions += "-DaltDeploymentRepository=" + env.ALT_SNAPSHOT_REPO_ID + '::' + env.ALT_SNAPSHOT_REPO_URL
                 }
                 mvnOptionsMap["global"] = env.GLOBAL_MAVEN_CLI_OPTS + " " + env.MAVEN_EXTRA_OPTS
                 def mvnOptions = mvnOptionsMap.values().join(" ")


### PR DESCRIPTION
I noticed the following warnings during M3 build:

~~~
[INFO] Using alternate deployment repository jfrog::default::https://openhab.jfrog.io/openhab/libs-milestone-local
[WARNING] Using legacy syntax for alternative repository. Use "jfrog::https://openhab.jfrog.io/openhab/libs-milestone-local" instead.
~~~

This PR tries to adapt the URL. I cannot test, though.