### PR TITLE
[Oomph installer] Add workarond for lastnpe in recent Eclipse

### DIFF
--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2372,6 +2372,10 @@
           url="https://ianbrandt.github.io/m2e-maven-dependency-plugin/"/>
       <repository
           url="https://www.lastnpe.org/eclipse-external-annotations-m2e-plugin-p2-site/m2e_2/"/>
+      <!-- workaround: lastnpe requires org.apache.commons.io which was renamed
+          to org.apache.commons.commons-io in Eclipse 2025-12 -->
+      <repository
+          url="https://download.eclipse.org/releases/2024-06/"/>
     </setupTask>
     <setupTask
         xsi:type="setup:ResourceCreationTask"


### PR DESCRIPTION
lastnpe m2e plugin requires commons.io, which is no longer available in Eclipse starting with 2025-12, as it was renamed to commons.commons-io.

Until lastnpe is released with a new requirement in MANIFEST.MF, an older installation source is required to safisfy this import. This leads to commons.io and commons.commons-io to be installed in parallel.

Fixes #1856 