### PR TITLE
Workaround deployment issues with karaf packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,15 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.1.4</version>
+          <configuration>
+            <!-- Workaround for deploy errors for karaf packaging projects with attached artifacts only -->
+            <allowIncompleteProjects>true</allowIncompleteProjects>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>3.6.1</version>


### PR DESCRIPTION
This should fix the current build/deployment issues, see https://ci.openhab.org/view/Sandbox/job/sandbox-openhab5-release/2009/execution/node/438/log/