### PR TITLE
[GHA] Fix rebuild label

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -50,16 +50,9 @@ jobs:
         echo "$GITHUB"
 
     - name: Checkout
-      if: ${{ github.head_ref == '' && env.LABEL == 'rebuild' }}
+      if: ${{ env.LABEL == 'rebuild' }}
       uses: actions/checkout@v7
       with:
-        persist-credentials: false
-
-    - name: Checkout merge
-      if: ${{ github.head_ref != '' && env.LABEL == 'rebuild' }}
-      uses: actions/checkout@v7
-      with:
-        ref: refs/pull/${{github.event.pull_request.number}}/merge
         persist-credentials: false
 
     - name: List Jobs


### PR DESCRIPTION
actions/checkout v7 no longer allows checking out foreign repositories, unless allow-unsafe-pr-checkout: true is specified. This PR actually removes the foreign repo checkout, as the gh tool calls should work on the base repo as well.

The rebuild label functionality does not work since #1924.
This is the same change as in add-ons repo: https://github.com/openhab/openhab-addons/pull/21183.