### PR TITLE
Remove pax-web patching by openhab-util library

### DIFF
--- a/distributions/openhab/pom.xml
+++ b/distributions/openhab/pom.xml
@@ -82,22 +82,6 @@
         </includes>
       </resource>
     </resources>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>exec-maven-plugin</artifactId>
-          <version>3.6.3</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.openhab.util</groupId>
-              <artifactId>pax-web-patch</artifactId>
-              <version>1.0.0</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-      </plugins>
-    </pluginManagement>
 
     <plugins>
       <plugin>
@@ -240,25 +224,6 @@
           <archiveZip>false</archiveZip>
           <archiveTarGz>false</archiveTarGz>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <configuration>
-          <mainClass>org.openhab.patch.ClassPathUtilPatcher</mainClass>
-          <arguments>
-            <argument>${project.basedir}/target/assembly/system/org/ops4j/pax/web/pax-web-api</argument>
-          </arguments>
-          <includePluginDependencies>True</includePluginDependencies>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>java</goal>
-            </goals>
-            <phase>prepare-package</phase>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This patching step has no longer worked for quite a while.

`findResources` was removed from pax-web upstream in January 2020 (commit `cf6861615`, part of the PAXWEB-1190 Http/Whiteboard refactor), replaced by the current `findEntries(...)` methods - over a year and a half *before* pax-web `8.0.0` GA even shipped (September 2021). Every pax-web 8.0.x version has no method by that name.

`ClassAdapter`'s method-matching (`"findResources".equals(name)`) therefore never fires, and `ClassPathUtilPatcher` has no verification step - it always prints `"Finished updating ..."` and exits 0 regardless of whether anything was actually patched.


@kaikreuzer Is seems you were right in https://github.com/openhab/openhab-util/pull/1#issuecomment-4186851515