### PR TITLE
Fix Windows startup helper script handling

### DIFF
--- a/distributions/openhab/src/main/resources/bin/karaf
+++ b/distributions/openhab/src/main/resources/bin/karaf
@@ -414,7 +414,7 @@ awaitOsgiCacheReady() {
         fi
         sleep 1
         SECONDS_WAITED=$((SECONDS_WAITED + 1))
-        if [ "${SECONDS_WAITED}" -ge 60 ]; then
+        if [ "${SECONDS_WAITED}" -ge 70 ]; then
             echo "Wait timed out!"
             break
         fi
@@ -433,7 +433,7 @@ awaitOsgiCacheReady() {
         fi
         sleep 1
         SECONDS_WAITED=$((SECONDS_WAITED + 1))
-        if [ "${SECONDS_WAITED}" -ge 30 ]; then
+        if [ "${SECONDS_WAITED}" -ge 70 ]; then
             echo "Wait timed out!"
             break
         fi

--- a/distributions/openhab/src/main/resources/bin/karaf.bat
+++ b/distributions/openhab/src/main/resources/bin/karaf.bat
@@ -126,7 +126,11 @@ if defined LEVEL (
     )
 )
 if !SECONDS_WAITED! GEQ 30 (
-    echo Wait timed out!
+    if not exist "%STARTLEVEL_FILE%" (
+        echo Wait timed out! .. missing start-level file %STARTLEVEL_FILE%
+        goto SERVER_STARTED
+    )
+    echo Wait timed out! .. did not reach start-level %STARTED_TARGET_LEVEL%
     goto SERVER_STARTED
 )
 timeout /t 1 /nobreak >nul
@@ -152,7 +156,11 @@ if defined LEVEL (
     )
 )
 if !SECONDS_WAITED! GEQ 30 (
-    echo Wait timed out!
+    if not exist "%STARTLEVEL_FILE%" (
+        echo Wait timed out! .. missing start-level file %STARTLEVEL_FILE%
+        goto SERVER_STOPPED
+    )
+    echo Wait timed out! .. did not reach start-level %STOPPED_TARGET_LEVEL%
     goto SERVER_STOPPED
 )
 timeout /t 1 /nobreak >nul

--- a/distributions/openhab/src/main/resources/bin/karaf.bat
+++ b/distributions/openhab/src/main/resources/bin/karaf.bat
@@ -93,6 +93,11 @@ goto AFTER_CACHE_READY
 set CACHE_FOLDER=%KARAF_DATA%\cache\org.eclipse.osgi
 if exist "%CACHE_FOLDER%\.*" goto AFTER_CACHE_READY
 
+if not exist "%DIRNAME%runhidden.vbs" (
+    call :warn Missing helper script: "%DIRNAME%runhidden.vbs"
+    goto END
+)
+
 set CACHE_REFRESH_LOCK=%KARAF_DATA%\cache-refresh-lock
 if exist "%CACHE_REFRESH_LOCK%" goto AFTER_CACHE_READY
 type nul > "%CACHE_REFRESH_LOCK%"
@@ -105,14 +110,9 @@ set STOPPED_TARGET_LEVEL=0
 
 set RUNHIDDEN=wscript //nologo "%DIRNAME%runhidden.vbs"
 
-if not exist "%DIRNAME%runhidden.vbs" (
-    call :warn Missing helper script: "%DIRNAME%runhidden.vbs"
-    goto END
-)
-
 echo Starting server...
 set KARAF_HOME=
-%RUNHIDDEN% """%~dp0karaf.bat"" server"
+%RUNHIDDEN% "%DIRNAME%karaf.bat" "server"
 setlocal EnableDelayedExpansion
 set SECONDS_WAITED=0
 
@@ -138,7 +138,7 @@ endlocal
 
 echo Finalizing startup sequence...
 set KARAF_HOME=
-%RUNHIDDEN% """%~dp0karaf.bat"" stop"
+%RUNHIDDEN% "%DIRNAME%karaf.bat" "stop"
 setlocal EnableDelayedExpansion
 set SECONDS_WAITED=0
 

--- a/distributions/openhab/src/main/resources/bin/karaf.bat
+++ b/distributions/openhab/src/main/resources/bin/karaf.bat
@@ -125,7 +125,7 @@ if defined LEVEL (
         if !LEVEL_A! GEQ %STARTED_TARGET_LEVEL% goto SERVER_STARTED
     )
 )
-if !SECONDS_WAITED! GEQ 30 (
+if !SECONDS_WAITED! GEQ 70 (
     if not exist "%STARTLEVEL_FILE%" (
         echo Wait timed out! .. missing start-level file %STARTLEVEL_FILE%
         goto SERVER_STARTED
@@ -155,7 +155,7 @@ if defined LEVEL (
         if !LEVEL_A! EQU %STOPPED_TARGET_LEVEL% goto SERVER_STOPPED
     )
 )
-if !SECONDS_WAITED! GEQ 30 (
+if !SECONDS_WAITED! GEQ 70 (
     if not exist "%STARTLEVEL_FILE%" (
         echo Wait timed out! .. missing start-level file %STARTLEVEL_FILE%
         goto SERVER_STOPPED

--- a/distributions/openhab/src/main/resources/bin/karaf.bat
+++ b/distributions/openhab/src/main/resources/bin/karaf.bat
@@ -103,8 +103,12 @@ set STARTED_TARGET_LEVEL=10
 set STOPPED_TARGET_LEVEL=0
 > "%STARTLEVEL_FILE%" echo %STOPPED_TARGET_LEVEL%
 
-set RUNHIDDEN=wscript //nologo "%TEMP%\runhidden.vbs"
-> "%TEMP%\runhidden.vbs" echo CreateObject("Wscript.Shell").Run WScript.Arguments(0), 0, False
+set RUNHIDDEN=wscript //nologo "%DIRNAME%runhidden.vbs"
+
+if not exist "%DIRNAME%runhidden.vbs" (
+    call :warn Missing helper script: "%DIRNAME%runhidden.vbs"
+    goto END
+)
 
 echo Starting server...
 set KARAF_HOME=

--- a/distributions/openhab/src/main/resources/bin/runhidden.vbs
+++ b/distributions/openhab/src/main/resources/bin/runhidden.vbs
@@ -1,0 +1,1 @@
+CreateObject("Wscript.Shell").Run WScript.Arguments(0), 0, False

--- a/distributions/openhab/src/main/resources/bin/runhidden.vbs
+++ b/distributions/openhab/src/main/resources/bin/runhidden.vbs
@@ -1,1 +1,1 @@
-CreateObject("Wscript.Shell").Run WScript.Arguments(0), 0, False
+CreateObject("WScript.Shell").Run Chr(34) & WScript.Arguments(0) & Chr(34) & Chr(32) & WScript.Arguments(1), 0, False


### PR DESCRIPTION
In #1922 we fixed the 'Terminal has been closed' error. The solution for Windows requires a helper Visual Basic Script file that executes some shell commands in a hidden window in order to avoid confusing users. The original solution created the helper VBS file on the fly in the Windows `temp` folder. However as reported and discussed in #1940 creating the script on the fly can create problems; specifically due to paths with spaces. And it leaves an orphan copy of the script file in the Windows `temp` folder.

In this PR we no longer create the helper Visual Basic Script on the fly, but instead we include it as a fixed part of the distribution. Furthermore the batch file and the script are modified to handle paths with spaces on Windows platforms.

Furthermore based on tests with slower machines, this PR increases the timeout durations accordingly.

Resolves #1940

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
