### PR TITLE
Upgrade Bnd to 7.x.x and lift Bndtools 7.0 pin

### DIFF
--- a/launch/app/pom.xml
+++ b/launch/app/pom.xml
@@ -16,7 +16,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <oh.java.version>21</oh.java.version>
     <maven.compiler.release>${oh.java.version}</maven.compiler.release>
-    <bnd.version>7.1.0</bnd.version>
+    <bnd.version>7.4.0</bnd.version>
   </properties>
 
   <dependencies>
@@ -230,7 +230,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.4.2</version>
+          <version>3.5.1</version>
         </plugin>
 
         <plugin>
@@ -280,34 +280,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.5.2</version>
-        </plugin>
-
-        <!-- This plugin's configuration is used to store Eclipse m2e settings only. -->
-        <!-- It has no influence on the Maven build itself. -->
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>biz.aQute.bnd</groupId>
-                    <artifactId>bnd-indexer-maven-plugin</artifactId>
-                    <versionRange>[3.1.0,)</versionRange>
-                    <goals>
-                      <goal>index</goal>
-                      <goal>local-index</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore></ignore>
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/launch/app/runtime/services.cfg
+++ b/launch/app/runtime/services.cfg
@@ -25,4 +25,4 @@ startlevel:70=dsl:sitemaps,yaml:sitemaps,managed:sitemap,yaml:pages,yaml:widgets
 startlevel:80=things:handler
 
 org.jupnp:threadPoolSize=20
-org.ops4j.pax.logging:org.ops4j.pax.logging.log4j2.config.file=../../../../runtime/log4j2.xml
+org.ops4j.pax.logging:org.ops4j.pax.logging.log4j2.config.file=runtime/log4j2.xml

--- a/launch/openHAB2.setup
+++ b/launch/openHAB2.setup
@@ -2356,8 +2356,7 @@
       <requirement
           name="org.eclipse.wst.web_ui.feature.feature.group"/>
       <requirement
-          name="bndtools.m2e.feature.feature.group"
-		  versionRange="[7.0.0,7.1.0)"/>
+          name="bndtools.m2e.feature.feature.group"/>
       <requirement
           name="org.lastnpe.m2e.feature.feature.group"/>
       <requirement


### PR DESCRIPTION
## Summary

Upgrade Bnd from 7.1.0 to 7.x.x and allow the Eclipse setup to use current Bndtools versions again.

The Bndtools version was [pinned to 7.0.x](https://github.com/openhab/openhab-distro/pull/1803) because Maven-backed `.bndrun` resolution stopped working with Bndtools 7.1 and newer. This change depends on [bndtools/bnd#7386](https://github.com/bndtools/bnd/pull/7386), which fixes the m2e integration issues affecting the openHAB Eclipse setup.

## Changes

- Upgrade Bnd Maven plugins from 7.1.0 to 7.x.x.
- Remove the obsolete `org.eclipse.m2e:lifecycle-mapping` configuration. Current Bndtools provides the required m2e lifecycle metadata itself.
- Remove the `[7.0.0,7.1.0)` Bndtools restriction from `openHAB2.setup`.
- Update the Pax Logging configuration path for the changed Maven `.bndrun` working-directory behavior in newer Bnd versions.

## Testing

Tested the openHAB `launch/app/app.bndrun` with Eclipse 2026-06 and Bndtools 7.4 including the fix from [bndtools/bnd#7386](https://github.com/bndtools/bnd/pull/7386).

The `.bndrun` resolves successfully, openHAB starts from Eclipse, and the configured console logging is available again.

The updated Bndtools m2e plugin can be installed from the Bndtools snapshot update site:

https://bndtools.jfrog.io/bndtools/update-snapshot

See the [Bndtools update site installation instructions](https://bndtools.org/installation.html#update-site-install) for details.

To install it in Eclipse:

1. Open **Help → Install New Software...**.
2. Add `https://bndtools.jfrog.io/bndtools/update-snapshot` as an update site.
3. Select the Bndtools/m2e features and complete the installation/update.
4. Restart Eclipse when prompted.
5. Open `launch/app/app.bndrun`, resolve it, and launch openHAB.

The expected result is that the run configuration resolves without the previous Maven/m2e errors and openHAB startup logging is shown in the Eclipse Console.